### PR TITLE
feat(auth): 이메일 회원가입 기능 및 로그인 상태 유지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<SignUp />} />
+        <Route path="/signup" element={<SignUp />} />
       </Routes>
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,10 @@
 import React, { useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
-import Login from "./components/AuthForm";
 import Home from "./pages/Home"; // 기본 홈화면
+import Login from "./components/AuthForm";
+import SignUp from "./pages/Auth/SignUp";
+
 import { observeAuth } from "./services/auth";
 import { useDispatch } from "react-redux";
 import { setUser, clearUser } from "./store/userSlice";
@@ -36,6 +38,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<SignUp />} />
       </Routes>
     </>
   );

--- a/src/components/AuthForm.jsx
+++ b/src/components/AuthForm.jsx
@@ -131,7 +131,7 @@ export default function AuthForm() {
 
         <div className="flex justify-between mt-6 text-sm text-gray-500">
           <Link to="/reset">비밀번호를 잊으셨나요?</Link>
-          <Link to="/register">회원가입</Link>
+          <Link to="/signup">회원가입</Link>
         </div>
 
         <footer className="text-xs text-center text-gray-400 mt-10">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,7 +27,7 @@ export default function Header() {
       ) : (
         <div className="flex gap-4">
           <Link to="/login">로그인</Link>
-          <Link to="/register">회원가입</Link>
+          <Link to="/signup">회원가입</Link>
         </div>
       )}
     </header>

--- a/src/pages/Auth/SignUp.jsx
+++ b/src/pages/Auth/SignUp.jsx
@@ -1,0 +1,96 @@
+// src/pages/Auth/SignUp.jsx
+import React, { useState } from "react";
+import { useDispatch } from "react-redux";
+import { useNavigate, Link } from "react-router-dom";
+import { setUser } from "../../store/userSlice";
+import { signUp } from "../../services/auth";
+
+export default function SignUp() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSignUp = async (e) => {
+    e.preventDefault();
+    setError("");
+
+    try {
+      const result = await signUp(email, password);
+      dispatch(
+        setUser({
+          uid: result.user.uid,
+          email: result.user.email,
+          displayName: result.user.displayName,
+          photoURL: result.user.photoURL,
+        })
+      );
+      navigate("/");
+    } catch (err) {
+      if (err.code === "auth/email-already-in-use") {
+        setError("이미 사용 중인 이메일입니다.");
+      } else if (err.code === "auth/weak-password") {
+        setError("비밀번호는 최소 6자 이상이어야 합니다.");
+      } else {
+        setError("회원가입에 실패했습니다.");
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="bg-white p-8 rounded shadow-md w-full max-w-md">
+        <h2 className="text-2xl font-bold text-center mb-6">회원가입</h2>
+
+        {error && (
+          <div className="text-red-500 text-sm mb-4 text-center">{error}</div>
+        )}
+
+        <form className="space-y-5" onSubmit={handleSignUp}>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium">
+              이메일
+            </label>
+            <input
+              id="email"
+              type="email"
+              placeholder="your@email.com"
+              className="w-full border border-gray-300 rounded px-3 py-2 mt-1"
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium">
+              비밀번호
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="w-full border border-gray-300 rounded px-3 py-2 mt-1"
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full bg-gray-900 text-white py-2 rounded hover:bg-black"
+          >
+            가입하기
+          </button>
+        </form>
+
+        <p className="text-sm text-center text-gray-500 mt-6">
+          이미 계정이 있으신가요?{" "}
+          <Link to="/login" className="text-blue-600 font-medium">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,6 +6,7 @@ const store = configureStore({
   reducer: {
     user: userReducer,
   },
+  devTools: process.env.NODE_ENV !== "production",
 });
 
 export default store;


### PR DESCRIPTION
## 주요 변경사항

- Firebase Auth 기반 이메일 회원가입 기능 구현
- createUserWithEmailAndPassword 메서드 사용
- 회원가입 성공 시 Redux에 사용자 정보 저장 후 홈으로 이동
- 중복 이메일 / 약한 비밀번호 등 에러 핸들링 추가
- onAuthStateChanged()를 통해 새로고침 후에도 로그인 상태 유지 처리
- Firebase 인증 객체는 serializable 문제가 없도록 필요한 정보만 추출해서 Redux 저장
- **회원가입 라우팅 경로를 `/register` → `/signup`으로 변경하여 명확성 개선**

## 테스트 체크리스트

- [x] 이메일/비밀번호로 회원가입 가능
- [x] 중복 이메일일 경우 에러 메시지 출력
- [x] 비밀번호가 6자 미만일 경우 에러 메시지 출력
- [x] 회원가입 성공 후 자동 로그인 및 홈 이동
- [x] Firebase 인증 상태 감지(onAuthStateChanged)로 로그인 상태 유지됨
- [x] Redux DevTools에서 로그인 정보 확인 가능
- [x] 기존 `/register` 경로는 제거, `/signup`으로 정상 이동됨
- [x] 로그인/로그아웃 플로우 문제없이 작동함

## 기타 참고

- 사용자 정보를 Firebase Auth의 User 객체 그대로 Redux에 저장하지 않고, 필요한 필드(uid, email 등)만 추려서 저장함 → 직렬화 경고 해결