### PR TITLE
feat: 리뷰 상세 조회 및 신고 기능 + 리뷰 목록 UI 개선 및 작성 버튼 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import EditItineraryPage from "pages/Itinerary/Edit";
 import CreateReviewPage from "./pages/Reviews/Create";
 import SignUp from "./pages/Auth/SignUp";
 import ReviewListPage from "./pages/Reviews/List";
+import ReviewDetailPage from "./pages/Reviews/Detail";
 
 function App() {
   const dispatch = useDispatch();
@@ -56,6 +57,7 @@ function App() {
         <Route path="/reviews">
           <Route index element={<ReviewListPage />} />
           <Route path="create" element={<CreateReviewPage />} />
+          <Route path=":id" element={<ReviewDetailPage />} />
         </Route>
       </Routes>
     </>

--- a/src/components/Review/ReportButton.jsx
+++ b/src/components/Review/ReportButton.jsx
@@ -1,0 +1,23 @@
+// src/components/Review/ReportButton.jsx
+import { useReportReview } from "services/queries/useReportReview";
+
+export default function ReportButton({ reviewId }) {
+  const reportMutation = useReportReview();
+
+  const handleReport = () => {
+    const reason = prompt("신고 사유를 입력해주세요:");
+    if (!reason) return;
+
+    reportMutation.mutate({ reviewId, reason });
+  };
+
+  return (
+    <button
+      onClick={handleReport}
+      disabled={reportMutation.isLoading}
+      className="text-sm text-red-500 hover:underline disabled:opacity-50"
+    >
+      {reportMutation.isLoading ? "신고 중..." : "신고하기"}
+    </button>
+  );
+}

--- a/src/components/Review/ReviewForm.jsx
+++ b/src/components/Review/ReviewForm.jsx
@@ -24,7 +24,7 @@ export default function ReviewForm({ onSubmit, isLoading }) {
   return (
     <form
       onSubmit={handleReviewFormSubmit}
-      className="bg-white p-8 rounded-2xl shadow-md border max-w-2xl mx-auto"
+      className="bg-white p-8 rounded-2xl shadow-md border max-w-4xl mx-auto"
     >
       <h2 className="text-2xl font-bold mb-6">리뷰 작성하기</h2>
 

--- a/src/components/Review/ReviewSortButtons.jsx
+++ b/src/components/Review/ReviewSortButtons.jsx
@@ -1,6 +1,6 @@
 export default function ReviewSortButtons({ sort, onChange }) {
   return (
-    <div className="flex justify-end mb-6 space-x-2">
+    <div className="flex justify-start mb-6 ml-5 space-x-2">
       <button
         className={`px-4 py-2 rounded-full text-sm font-medium border transition ${
           sort === "latest"

--- a/src/pages/Itinerary/List.jsx
+++ b/src/pages/Itinerary/List.jsx
@@ -15,9 +15,8 @@ export default function ItineraryListPage() {
   if (!data || data.length === 0)
     return (
       <EmptyState
-        icon="📝"
-        title="아직 등록된 리뷰가 없습니다"
-        description="다녀온 여행의 후기를 남겨보세요!"
+        title="등록된 일정이 없습니다"
+        description="새로운 여행 일정을 작성해보세요!"
       />
     );
 

--- a/src/pages/Reviews/Detail.jsx
+++ b/src/pages/Reviews/Detail.jsx
@@ -1,0 +1,55 @@
+// src/pages/Reviews/Detail.jsx
+import { useParams } from "react-router-dom";
+import { useReviewDetail } from "services/queries/useReviewDetail";
+import LoadingSpinner from "components/LoadingSpinner";
+import NotFoundMessage from "components/NotFoundMessage";
+import ReportButton from "components/Review/ReportButton";
+
+export default function ReviewDetailPage() {
+  const { id } = useParams();
+  const { data, isLoading, isError } = useReviewDetail(id);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (isError || !data)
+    return <NotFoundMessage message="리뷰를 찾을 수 없습니다." />;
+
+  const {
+    title,
+    destination,
+    content,
+    rating,
+    authorName,
+    createdAt,
+    imageUrl,
+  } = data;
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4 bg-white rounded-lg shadow-sm">
+      <h1 className="text-2xl font-bold mb-2">{title}</h1>
+      <p className="text-gray-500 text-sm mb-4">
+        {destination} · ⭐ {rating} · {authorName}
+      </p>
+      <p className="text-gray-400 text-xs mb-6">
+        {createdAt?.toDate?.().toLocaleString() || "날짜 없음"}
+      </p>
+
+      {imageUrl && (
+        <div className="mb-6">
+          <img
+            src={imageUrl}
+            alt="리뷰 이미지"
+            className="w-full max-h-[400px] object-cover rounded-lg"
+          />
+        </div>
+      )}
+
+      <div className="text-gray-800 leading-relaxed mb-6 whitespace-pre-line">
+        {content}
+      </div>
+
+      <div className="flex justify-end">
+        <ReportButton reviewId={id} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Reviews/List.jsx
+++ b/src/pages/Reviews/List.jsx
@@ -1,15 +1,20 @@
 // src/pages/Reviews/List.jsx
 import ReviewList from "components/Review/ReviewList";
+import { Link } from "react-router-dom";
 
 export default function ReviewListPage() {
   return (
-    <div className="min-h-screen bg-gray-100 py-12 px-4">
-      <div className="max-w-6xl mx-auto">
-        <h1 className="text-3xl font-bold text-center text-gray-800 mb-10">
-          여행 리뷰 목록
-        </h1>
-        <ReviewList />
+    <div className="max-w-4xl mx-auto px-4 mt-10">
+      <div className="flex justify-between items-center mb-20">
+        <h2 className="text-2xl font-bold">여행 리뷰 목록</h2>
+        <Link
+          to="/reviews/create"
+          className="bg-gray-900 text-white text-sm px-4 py-2 rounded hover:bg-gray-800 transition"
+        >
+          리뷰 작성하기
+        </Link>
       </div>
+      <ReviewList />
     </div>
   );
 }

--- a/src/services/queries/useReportReview.js
+++ b/src/services/queries/useReportReview.js
@@ -1,0 +1,29 @@
+// src/services/queries/useReportReview.js
+import { useMutation } from "@tanstack/react-query";
+import { db } from "../firebase";
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+import { useSelector } from "react-redux";
+
+export const useReportReview = () => {
+  const user = useSelector((state) => state.user.user);
+
+  return useMutation({
+    mutationFn: async ({ reviewId, reason }) => {
+      if (!reviewId || !reason) throw new Error("신고 정보가 부족합니다.");
+
+      await addDoc(collection(db, "review_reports"), {
+        reviewId,
+        reason,
+        reportedAt: serverTimestamp(),
+        reporterId: user?.uid || "anonymous",
+      });
+    },
+    onSuccess: () => {
+      alert("신고가 접수되었습니다.");
+    },
+    onError: (error) => {
+      console.error(error);
+      alert("신고 처리 중 오류가 발생했습니다.");
+    },
+  });
+};

--- a/src/services/queries/useReviewDetail.js
+++ b/src/services/queries/useReviewDetail.js
@@ -1,0 +1,21 @@
+// src/services/queries/useReviewDetail.js
+import { useQuery } from "@tanstack/react-query";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../firebase";
+
+export const useReviewDetail = (id) => {
+  return useQuery({
+    queryKey: ["review", id],
+    queryFn: async () => {
+      const docRef = doc(db, "reviews", id);
+      const snapshot = await getDoc(docRef);
+
+      if (!snapshot.exists()) {
+        throw new Error("리뷰가 존재하지 않습니다.");
+      }
+
+      return { id: snapshot.id, ...snapshot.data() };
+    },
+    enabled: !!id, // id가 있을 때만 실행
+  });
+};


### PR DESCRIPTION
## 주요 변경 사항
- 리뷰 상세 페이지 구현 (/reviews/:id)
- 여행지명, 별점, 본문, 작성자, 작성일 출력
- 잘못된 ID 접근 시 오류 처리 (isError 활용)
- 로딩 중 스피너 출력
- 리뷰 신고 기능 추가
- “신고하기” 버튼 → 신고 사유 입력(prompt) → Firestore review_reports 컬렉션에 저장
- 신고 성공 시 사용자 알림(alert) 표시
- 리뷰 목록 페이지 UI 개선
- 페이지 우측 상단에 “리뷰 작성하기” 버튼 추가
- 카드 레이아웃 개선 (반응형 그리드, 마진/정렬 통일)
- 일정 목록 UI와 디자인 통일감 유지

## 테스트 체크
- 유효한 리뷰 ID 접근 시 상세 정보 출력
- 잘못된 리뷰 ID 접근 시 오류 처리됨
- 신고 사유 입력 후 정상적으로 Firestore 저장됨
- 신고 성공 후 알림 메시지 출력됨
- 리뷰 목록 UI 레이아웃 정상 출력
- “리뷰 작성하기” 버튼 정상 작동