### PR TITLE
feat: 채팅 메시지 신고 기능 구현

### DIFF
--- a/src/components/ReportModal.jsx
+++ b/src/components/ReportModal.jsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { useReportMessage } from "services/queries/useReportMessage";
+
+export default function ReportModal({ messageId, roomId, onClose }) {
+  const [reason, setReason] = useState("");
+  const { mutateAsync, isPending } = useReportMessage();
+
+  const handleReportModalSubmit = async () => {
+    if (!reason.trim()) {
+      alert("신고 사유를 입력해주세요.");
+      return;
+    }
+
+    try {
+      await mutateAsync({ messageId, roomId, reason });
+      alert("신고가 접수되었습니다.");
+      onClose();
+    } catch (err) {
+      console.error("신고 오류:", err);
+      alert("신고 처리 중 오류가 발생했어요.");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-sm shadow-lg">
+        <h3 className="text-lg font-semibold mb-4">메시지 신고하기</h3>
+
+        <textarea
+          rows={3}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          className="w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-400"
+          placeholder="신고 사유를 입력해주세요"
+        />
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 rounded-md text-sm"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleReportModalSubmit}
+            disabled={isPending}
+            className="px-4 py-2 bg-red-500 text-white rounded-md text-sm"
+          >
+            {isPending ? "신고 중..." : "신고하기"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ChatMessage.jsx
+++ b/src/components/chat/ChatMessage.jsx
@@ -2,18 +2,22 @@
 import { useSelector } from "react-redux";
 import { formatRelative } from "date-fns";
 import { ko } from "date-fns/locale";
+import { useState } from "react";
+import ReportModal from "../ReportModal";
 
 export default function ChatMessage({ message }) {
   const user = useSelector((state) => state.user.user);
   const isMine = message.senderId === user?.uid;
+  const [openReportModal, setOpenReportModal] = useState(false);
 
   return (
     <div className={`flex ${isMine ? "justify-end" : "justify-start"}`}>
       <div className="max-w-xs">
+        {/* 상대방 이름 표시 */}
         {!isMine && (
           <p className="text-xs text-gray-500 mb-1">{message.senderName}</p>
         )}
-
+        {/* 말풍선 */}
         <div
           className={`px-4 py-2 rounded-xl text-sm ${
             isMine
@@ -24,6 +28,17 @@ export default function ChatMessage({ message }) {
           {message.message}
         </div>
 
+        {/* 신고 버튼 (본인 제외) */}
+        {!isMine && (
+          <button
+            onClick={() => setOpenReportModal(true)}
+            className="text-xs text-gray-500 mt-1 hover:underline"
+          >
+            신고
+          </button>
+        )}
+
+        {/* 시간 표시 */}
         <p className="text-[10px] text-gray-400 mt-1 text-right">
           {message.createdAt?.toDate
             ? formatRelative(message.createdAt.toDate(), new Date(), {
@@ -31,6 +46,15 @@ export default function ChatMessage({ message }) {
               })
             : ""}
         </p>
+
+        {/* 신고 모달 조건부 렌더링 */}
+        {openReportModal && (
+          <ReportModal
+            messageId={message.id}
+            roomId={message.roomId}
+            onClose={() => setOpenReportModal(false)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/services/queries/useReportMessage.js
+++ b/src/services/queries/useReportMessage.js
@@ -10,7 +10,7 @@ export const useReportMessage = () => {
     mutationFn: async ({ messageId, roomId, reason }) => {
       if (!user) throw new Error("로그인 정보가 없습니다");
 
-      await addDoc(collection(db, "reports/chats"), {
+      await addDoc(collection(db, "chatReports"), {
         messageId,
         roomId,
         reporterId: user.uid,

--- a/src/services/queries/useReportMessage.js
+++ b/src/services/queries/useReportMessage.js
@@ -1,0 +1,22 @@
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { db } from "../firebase";
+import { useSelector } from "react-redux";
+import { useMutation } from "@tanstack/react-query";
+
+export const useReportMessage = () => {
+  const user = useSelector((state) => state.user.user);
+
+  return useMutation({
+    mutationFn: async ({ messageId, roomId, reason }) => {
+      if (!user) throw new Error("로그인 정보가 없습니다");
+
+      await addDoc(collection(db, "reports/chats"), {
+        messageId,
+        roomId,
+        reporterId: user.uid,
+        reason,
+        reportedAt: serverTimestamp(),
+      });
+    },
+  });
+};


### PR DESCRIPTION
### 주요 기능
- 각 메시지에 '신고하기' 버튼 추가
- 신고 클릭 시 신고 모달(`ReportModal`) 열림
- 사용자 입력 신고 사유를 기반으로 Firestore 저장
  - 저장 경로: `chatReports` 컬렉션
  - 저장 필드: messageId, roomId, reporterId, reason, reportedAt
- 신고 완료 시 알림 및 모달 닫힘 처리

### 예외 처리
- 신고 사유가 비어 있을 경우 alert 표시
- 신고 중에는 버튼 비활성화 처리
- Firestore 경로 오류(`reports/chats`) → `chatReports`로 수정 완료

### 테스트 체크리스트
- [x] 신고 버튼 클릭 시 모달 정상 출력
- [x] 사유 입력 후 신고 → Firestore에 저장됨
- [x] 신고 완료 후 모달 닫힘 + 알림 표시
- [x] 동일 메시지에 대해 중복 신고 가능 (MVP 기준 허용)

---

> 이후 버전 개선 예정:
- 동일 유저가 동일 메시지에 중복 신고 방지 처리