### PR TITLE
feat(admin): 관리자 보호 라우팅 구현 (Firebase 인증 + 이메일 검증)

### DIFF
--- a/loneleap-admin/components/auth/AdminProtectedRoute.jsx
+++ b/loneleap-admin/components/auth/AdminProtectedRoute.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "@/lib/firebase";
+import { adminEmails } from "@/lib/constants";
+import LoadingSpinner from "../LoadingSpinner";
+
+export default function AdminProtectedRoute({ children }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      const isAdmin = user && adminEmails.includes(user.email);
+      if (!isAdmin) {
+        router.replace("/admin/login");
+      } else {
+        setLoading(false);
+      }
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/loneleap-admin/lib/constants.js
+++ b/loneleap-admin/lib/constants.js
@@ -1,0 +1,5 @@
+// loneleap-admin/lib/constants.js
+export const adminEmails = [
+  "admin@gmail.com", // 실제 운영 관리자 계정
+  "owner@example.com", // 테스트용 계정
+];

--- a/loneleap-admin/pages/admin/dashboard.js
+++ b/loneleap-admin/pages/admin/dashboard.js
@@ -1,0 +1,13 @@
+// loneleap-admin/pages/admin/dashboard.js
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+
+export default function AdminDashboardPage() {
+  return (
+    <AdminProtectedRoute>
+      <div className="p-6">
+        <h1 className="text-2xl font-bold">관리자 대시보드</h1>
+        {/* TODO: 이후 대시보드 기능 추가 */}
+      </div>
+    </AdminProtectedRoute>
+  );
+}


### PR DESCRIPTION
## ✨ 작업 개요

- 관리자 전용 페이지(`/admin/*`)에 대한 보호 라우팅 구현
- Firebase 인증 상태 확인 + 관리자 이메일 검증을 모두 통과한 경우에만 접근 허용

## 주요 변경 사항

- `AdminProtectedRoute` 컴포넌트 생성 (공통 보호 컴포넌트)
- Firebase `onAuthStateChanged`로 로그인 상태 실시간 감지
- `adminEmails` 배열 기반 이메일 인증 방식 적용
- 인증되지 않은 사용자는 `/admin/login`으로 리다이렉트 처리
- 인증 확인 전에는 `LoadingSpinner`를 표시하여 깜빡임 방지

## 테스트 체크리스트

- [x] 로그인하지 않은 상태에서 `/admin/dashboard` 접근 시 → `/admin/login`으로 이동
- [x] 일반 사용자 계정으로 로그인 시 → 관리자 페이지 접근 차단
- [x] 관리자 이메일 계정 로그인 시 → 관리자 페이지 접근 가능
- [x] 로그인 후 새로고침해도 상태 유지됨
- [x] 주소창 직접 입력해도 보호 라우팅 정상 작동

## 적용 위치

- `components/auth/AdminProtectedRoute.jsx`
- `lib/constants.js`
- `pages/admin/dashboard.js` (보호 라우팅 적용 예시)

## 기타 참고

- 추후 `/admin/*` 하위 페이지에서도 동일 방식으로 보호 라우팅 래핑 필요
- 관리자 계정 추가 시 `adminEmails` 배열에 이메일만 추가하면 반영됨