### PR TITLE
feat(admin): 대시보드 초기 구성 및 관리자 404 페이지 커스터마이징

### DIFF
--- a/loneleap-admin/components/layout/AdminLayout.jsx
+++ b/loneleap-admin/components/layout/AdminLayout.jsx
@@ -1,0 +1,55 @@
+// 📁 loneleap-admin/components/layout/AdminLayout.jsx
+import { signOut } from "firebase/auth";
+import { auth } from "@/lib/firebase";
+import { useRouter } from "next/router";
+import Link from "next/link";
+
+export default function AdminLayout({ children }) {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await signOut(auth);
+    router.push("/admin/login");
+  };
+
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      {/* Sidebar */}
+      <aside className="w-64 bg-white border-r shadow-sm flex flex-col justify-between">
+        <div>
+          <div className="p-6 text-xl font-bold border-b">LoneLeap 관리자</div>
+          <nav className="flex flex-col gap-2 px-6 py-4 text-sm text-gray-700">
+            <Link href="/admin/dashboard" className="hover:text-black">
+              🏠 대시보드
+            </Link>
+            <Link href="/admin/reports/reviews" className="hover:text-black">
+              📝 리뷰 신고
+            </Link>
+            <Link href="/admin/reports/chats" className="hover:text-black">
+              💬 채팅 신고
+            </Link>
+            <Link href="/admin/users" className="hover:text-black">
+              👤 사용자 관리
+            </Link>
+            <Link href="/admin/spots" className="hover:text-black">
+              📍 추천 여행지 관리
+            </Link>
+          </nav>
+        </div>
+
+        {/* 로그아웃 버튼 */}
+        <div className="p-6 border-t">
+          <button
+            onClick={handleLogout}
+            className="w-full text-sm text-gray-500 hover:text-red-500 border px-3 py-2 rounded"
+          >
+            로그아웃
+          </button>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 p-8 overflow-y-auto">{children}</main>
+    </div>
+  );
+}

--- a/loneleap-admin/pages/404.js
+++ b/loneleap-admin/pages/404.js
@@ -1,0 +1,32 @@
+// pages/404.js
+import { useRouter } from "next/router";
+import AdminLayout from "@/components/layout/AdminLayout";
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+
+export default function Custom404() {
+  const router = useRouter();
+  const isAdminPage = router.asPath.startsWith("/admin");
+
+  if (isAdminPage) {
+    return (
+      <AdminProtectedRoute>
+        <AdminLayout>
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <h1 className="text-3xl font-bold mb-4">
+              페이지를 찾을 수 없습니다
+            </h1>
+            <p className="text-gray-500">존재하지 않는 관리자 경로입니다.</p>
+          </div>
+        </AdminLayout>
+      </AdminProtectedRoute>
+    );
+  }
+
+  // 일반 유저용 404
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <h1 className="text-3xl font-bold mb-4">404 - Page Not Found</h1>
+      <p className="text-gray-500">존재하지 않는 페이지입니다.</p>
+    </div>
+  );
+}

--- a/loneleap-admin/pages/404.js
+++ b/loneleap-admin/pages/404.js
@@ -2,23 +2,24 @@
 import { useRouter } from "next/router";
 import AdminLayout from "@/components/layout/AdminLayout";
 import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import { useState, useEffect } from "react";
 
 export default function Custom404() {
   const router = useRouter();
-  const isAdminPage = router.asPath.startsWith("/admin");
+  const [isAdminPage, setIsAdminPage] = useState(false);
+
+  useEffect(() => {
+    setIsAdminPage(router.asPath.startsWith("/admin"));
+  }, [router.asPath]);
 
   if (isAdminPage) {
     return (
-      <AdminProtectedRoute>
-        <AdminLayout>
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <h1 className="text-3xl font-bold mb-4">
-              페이지를 찾을 수 없습니다
-            </h1>
-            <p className="text-gray-500">존재하지 않는 관리자 경로입니다.</p>
-          </div>
-        </AdminLayout>
-      </AdminProtectedRoute>
+      <AdminLayout>
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <h1 className="text-3xl font-bold mb-4">페이지를 찾을 수 없습니다</h1>
+          <p className="text-gray-500">존재하지 않는 관리자 경로입니다.</p>
+        </div>
+      </AdminLayout>
     );
   }
 

--- a/loneleap-admin/pages/admin/dashboard.js
+++ b/loneleap-admin/pages/admin/dashboard.js
@@ -1,13 +1,86 @@
-// loneleap-admin/pages/admin/dashboard.js
+// 📁 loneleap-admin/pages/admin/dashboard.js
 import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import AdminLayout from "@/components/layout/AdminLayout";
+import Link from "next/link";
 
-export default function AdminDashboardPage() {
+export default function AdminDashboard() {
   return (
     <AdminProtectedRoute>
-      <div className="p-6">
-        <h1 className="text-2xl font-bold">관리자 대시보드</h1>
-        {/* TODO: 이후 대시보드 기능 추가 */}
-      </div>
+      <AdminLayout>
+        <div className="p-6">
+          {/* 상단 환영 메시지 */}
+          <h1 className="text-2xl font-bold mb-2">안녕하세요, 관리자님</h1>
+          <p className="text-gray-500 mb-6">2025년 4월 11일 금요일</p>
+
+          {/* 통계 카드 영역 */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div className="bg-white p-4 rounded-xl shadow">
+              신고된 리뷰: <strong>32</strong>
+            </div>
+            <div className="bg-white p-4 rounded-xl shadow">
+              신고된 채팅: <strong>18</strong>
+            </div>
+            <div className="bg-white p-4 rounded-xl shadow">
+              활성 사용자: <strong>2,847명</strong>
+            </div>
+          </div>
+
+          {/* 차트 박스 영역 */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <div className="bg-white p-6 h-60 rounded-xl shadow flex items-center justify-center text-gray-400">
+              라인 차트 영역
+            </div>
+            <div className="bg-white p-6 h-60 rounded-xl shadow flex items-center justify-center text-gray-400">
+              바 차트 영역
+            </div>
+          </div>
+
+          {/* 최근 신고 내역 (테이블 자리) */}
+          <div className="bg-white p-6 rounded-xl shadow">
+            <div className="flex justify-between mb-4">
+              <h2 className="text-lg font-semibold">최근 신고 내역</h2>
+              <Link href="#" className="text-sm text-blue-500">
+                전체보기 →
+              </Link>
+            </div>
+            <table className="w-full text-sm text-left">
+              <thead>
+                <tr className="text-gray-500 border-b">
+                  <th className="py-2">유형</th>
+                  <th className="py-2">내용</th>
+                  <th className="py-2">신고자</th>
+                  <th className="py-2">상태</th>
+                  <th className="py-2">시간</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b">
+                  <td className="py-2">리뷰</td>
+                  <td className="py-2">부적절한 내용 포함</td>
+                  <td className="py-2">김철수</td>
+                  <td className="py-2">
+                    <span className="bg-gray-200 text-gray-600 px-2 py-1 rounded-full text-xs">
+                      처리중
+                    </span>
+                  </td>
+                  <td className="py-2">10분 전</td>
+                </tr>
+                <tr>
+                  <td className="py-2">채팅</td>
+                  <td className="py-2">스팸 메시지</td>
+                  <td className="py-2">이영희</td>
+                  <td className="py-2">
+                    <span className="bg-gray-100 text-gray-500 px-2 py-1 rounded-full text-xs">
+                      완료
+                    </span>
+                  </td>
+                  <td className="py-2">25분 전</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </AdminLayout>
     </AdminProtectedRoute>
   );
 }

--- a/loneleap-admin/pages/admin/reports/chats.js
+++ b/loneleap-admin/pages/admin/reports/chats.js
@@ -1,0 +1,25 @@
+// 📁 loneleap-admin/pages/admin/reports/chats.js
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import AdminLayout from "@/components/layout/AdminLayout";
+
+export default function AdminChatReportsPage() {
+  return (
+    <AdminProtectedRoute>
+      <AdminLayout>
+        <div>
+          <h1 className="text-2xl font-bold mb-4">채팅 신고 목록</h1>
+          <p className="text-gray-600 mb-6">
+            사용자들이 신고한 채팅방 내용을 확인하고 처리할 수 있습니다.
+          </p>
+
+          {/* 신고 목록 테이블 자리 */}
+          <div className="bg-white p-6 rounded-xl shadow">
+            <div className="text-sm text-gray-400">
+              신고된 채팅 데이터 로딩 예정...
+            </div>
+          </div>
+        </div>
+      </AdminLayout>
+    </AdminProtectedRoute>
+  );
+}

--- a/loneleap-admin/pages/admin/reports/reviews.js
+++ b/loneleap-admin/pages/admin/reports/reviews.js
@@ -1,0 +1,25 @@
+// 📁 loneleap-admin/pages/admin/reports/reviews.js
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import AdminLayout from "@/components/layout/AdminLayout";
+
+export default function AdminReviewReportsPage() {
+  return (
+    <AdminProtectedRoute>
+      <AdminLayout>
+        <div>
+          <h1 className="text-2xl font-bold mb-4">리뷰 신고 목록</h1>
+          <p className="text-gray-600 mb-6">
+            사용자들이 신고한 리뷰를 확인하고 처리할 수 있습니다.
+          </p>
+
+          {/* 신고 목록 테이블 자리 */}
+          <div className="bg-white p-6 rounded-xl shadow">
+            <div className="text-sm text-gray-400">
+              신고된 리뷰 데이터 로딩 예정...
+            </div>
+          </div>
+        </div>
+      </AdminLayout>
+    </AdminProtectedRoute>
+  );
+}

--- a/loneleap-admin/pages/admin/spots.js
+++ b/loneleap-admin/pages/admin/spots.js
@@ -1,0 +1,21 @@
+// loneleap-admin/pages/admin/spots.js
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import AdminLayout from "@/components/layout/AdminLayout";
+
+export default function AdminSpotsPage() {
+  return (
+    <AdminProtectedRoute>
+      <AdminLayout>
+        <div className="flex flex-col items-center justify-center h-full py-24 text-center">
+          <h1 className="text-2xl font-bold mb-4">추천 여행지 관리</h1>
+          <p className="text-gray-500 max-w-md">
+            이 페이지는{" "}
+            <span className="font-semibold text-gray-700">v4.0</span> 버전에서
+            도입될 예정입니다.
+            <br /> 여행지 데이터 등록, 수정, 삭제 기능이 제공될 예정이에요.
+          </p>
+        </div>
+      </AdminLayout>
+    </AdminProtectedRoute>
+  );
+}

--- a/loneleap-admin/pages/admin/users.js
+++ b/loneleap-admin/pages/admin/users.js
@@ -1,0 +1,22 @@
+// loneleap-admin/pages/admin/users.js
+import AdminProtectedRoute from "@/components/auth/AdminProtectedRoute";
+import AdminLayout from "@/components/layout/AdminLayout";
+
+export default function AdminUsersPage() {
+  return (
+    <AdminProtectedRoute>
+      <AdminLayout>
+        <div className="flex flex-col items-center justify-center h-full py-24 text-center">
+          <h1 className="text-2xl font-bold mb-4">사용자 관리</h1>
+          <p className="text-gray-500 max-w-md">
+            이 페이지는{" "}
+            <span className="font-semibold text-gray-700">v3.0</span> 버전에서
+            도입될 예정입니다.
+            <br /> 사용자 목록, 신고 이력 확인, 계정 정지 기능이 제공될
+            예정이에요.
+          </p>
+        </div>
+      </AdminLayout>
+    </AdminProtectedRoute>
+  );
+}


### PR DESCRIPTION
## 관리자 대시보드 초기 세팅 & 404 예외 처리

관리자 로그인 후 진입하는 대시보드 페이지의 기본 레이아웃을 구성하고,  
존재하지 않는 관리자 경로 접근 시 전용 404 안내가 출력되도록 처리했습니다.

---

### 관리자 대시보드 구성
- 페이지 경로: `/admin/dashboard`
- 환영 문구 + 신고 관리 링크 (`/reports/reviews`, `/reports/chats`)
- 추후 통계 카드/차트 삽입을 위한 공간 미리 확보
- 공통 레이아웃 `AdminLayout` 구성
- 사이드바 내 **로그아웃 버튼** 추가

---

### 404 페이지 커스터마이징 & 에러 해결
- 관리자 경로(`/admin/*`)에서 잘못된 경로 접근 시 전용 안내 메시지 출력
- 일반 사용자 경로는 기존 404 메시지 유지
- `router.asPath`를 SSR에서 바로 사용하지 않고, `useEffect` 내에서 분기 처리하여 Hydration 에러 해결

---

### 테스트 체크리스트
- [x] `/admin/dashboard` 진입 시 기본 레이아웃 정상 출력
- [x] 각 이동 링크 작동 확인 (리뷰/채팅 신고 scaffold 페이지)
- [x] `/admin/없는경로` 진입 시 관리자용 404 안내 출력
- [x] 일반 사용자용 404 페이지는 기존대로 작동
- [x] Hydration failed 에러 발생하지 않음