### PR TITLE
feat: 관리자 신고 목록 UI 개선 및 페이지네이션 기능 추가

### DIFF
--- a/loneleap-admin/pages/admin/reports/chats.js
+++ b/loneleap-admin/pages/admin/reports/chats.js
@@ -71,15 +71,24 @@ export default function AdminChatReportsPage() {
 
           {/* 우측 - 상세 */}
           <div className="w-1/2 bg-white p-6 rounded-xl shadow min-h-[300px]">
-            <ChatReportDetail
-              report={selectedReport}
-              onSuccess={(deletedReport) => {
-                setReports((prev) =>
-                  prev.filter((r) => r.id !== deletedReport.id)
-                );
-                setSelectedReport(null);
-              }}
-            />
+            {selectedReport ? (
+              <ChatReportDetail
+                report={selectedReport}
+                onSuccess={(deletedReport) => {
+                  setReports((prev) =>
+                    prev.filter((r) => r.id !== deletedReport.id)
+                  );
+                  setSelectedReport(null);
+                }}
+              />
+            ) : (
+              <div className="flex flex-col items-center justify-center h-full text-gray-500">
+                <p>선택된 신고가 없습니다.</p>
+                <p className="text-sm mt-2">
+                  왼쪽 목록에서 신고를 선택해주세요.
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </AdminLayout>

--- a/loneleap-admin/pages/admin/reports/reviews.js
+++ b/loneleap-admin/pages/admin/reports/reviews.js
@@ -17,6 +17,7 @@ export default function AdminReviewReportsPage() {
   const [reports, setReports] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedReport, setSelectedReport] = useState(null);
+  const [error, setError] = useState(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -29,6 +30,7 @@ export default function AdminReviewReportsPage() {
       }
 
       try {
+        setError(null);
         const token = await user.getIdToken();
         const res = await fetch("/api/reviewReports/getReviewReports", {
           headers: {
@@ -36,10 +38,18 @@ export default function AdminReviewReportsPage() {
           },
         });
 
+        if (!res.ok) {
+          const errorData = await res.json();
+          throw new Error(
+            errorData.error || "데이터를 불러오는데 실패했습니다"
+          );
+        }
+
         const data = await res.json();
         setReports(data);
       } catch (error) {
         console.error("신고 리뷰 불러오기 실패:", error);
+        setError(error.message || "데이터를 불러오는데 실패했습니다");
       } finally {
         setLoading(false);
       }
@@ -68,6 +78,17 @@ export default function AdminReviewReportsPage() {
           <div className="w-1/2 bg-white p-6 rounded-xl shadow">
             {loading ? (
               <LoadingSpinner text="신고된 리뷰 데이터를 불러오는 중..." />
+            ) : error ? (
+              <div className="text-red-500 p-4 text-center">
+                <p className="font-semibold mb-2">오류 발생</p>
+                <p>{error}</p>
+                <button
+                  onClick={() => window.location.reload()}
+                  className="mt-3 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+                >
+                  다시 시도
+                </button>
+              </div>
             ) : (
               <ReviewReportTable
                 reports={reports}

--- a/loneleap-admin/pages/admin/reports/reviews.js
+++ b/loneleap-admin/pages/admin/reports/reviews.js
@@ -72,6 +72,7 @@ export default function AdminReviewReportsPage() {
               <ReviewReportTable
                 reports={reports}
                 onSelect={setSelectedReport}
+                selectedReportId={selectedReport?.id}
               />
             )}
           </div>

--- a/loneleap-admin/pages/api/chatReports/dismissChatReport.js
+++ b/loneleap-admin/pages/api/chatReports/dismissChatReport.js
@@ -21,6 +21,15 @@ export default async function dismissChatReport(req, res) {
       return res.status(404).json({ error: "해당 신고를 찾을 수 없습니다." });
     }
 
+    // 감사 로그 추가
+    await db.collection("adminLogs").add({
+      action: "dismissChatReport",
+      adminId: req.session?.user?.id, // 세션에서 관리자 ID 가져오기
+      reportId: reportId,
+      reportData: doc.data(), // 삭제 전 데이터 보존
+      timestamp: new Date(),
+    });
+
     await docRef.delete();
 
     return res.status(200).json({ message: "신고 삭제 완료" });


### PR DESCRIPTION
### 주요 변경사항
- 채팅 신고 무시 처리 시 감사 로그(adminLogs) 기록 추가 → 삭제 작업 추적 가능 (action, adminId, timestamp 포함)
- Empty 상태 안내 UI 추가 → 신고 항목이 없을 경우 피드백 메시지 표시 (사용자 혼란 방지)
- getChatReports API에 커서 기반 페이지네이션 도입 → limit, lastDocId 쿼리 파라미터 처리 추가
- 리뷰 신고 목록 UI 페이지네이션 처리 → getReviewReports API에 limit, lastDoc 기반 커서 처리 적용
- ReviewReportTable에 선택 항목 시각화 기능 추가 → selectedReportId 전달로 선택 상태 시각적으로 구분
- 리뷰 신고 목록 조회 실패 시 사용자 피드백 표시 → API 호출 실패 시 화면에 오류 안내 문구 표시 (setError 활용)

### 기타
- 클라이언트 요청 시 limit, lastDoc 쿼리 적용 필요
- 기존 UI 흐름은 유지하며 내부 동작 로직만 개선됨
