### PR TITLE
fix: 관리자 인증 및 삭제 처리 안정화, 에러 응답 상세 정보 개선

### DIFF
--- a/loneleap-admin/components/reports/ChatReportDetail.jsx
+++ b/loneleap-admin/components/reports/ChatReportDetail.jsx
@@ -43,7 +43,12 @@ export default function ChatReportDetail({ report, onSuccess }) {
 
       <DetailSection title="신고일자">
         {reportedAt
-          ? format(new Date(reportedAt), "yyyy.MM.dd HH:mm")
+          ? (() => {
+              const date = new Date(reportedAt);
+              return !isNaN(date.getTime())
+                ? format(date, "yyyy.MM.dd HH:mm")
+                : "유효하지 않은 날짜";
+            })()
           : "날짜 없음"}
       </DetailSection>
 

--- a/loneleap-admin/components/reports/ChatReportDetail.jsx
+++ b/loneleap-admin/components/reports/ChatReportDetail.jsx
@@ -48,7 +48,10 @@ export default function ChatReportDetail({ report, onSuccess }) {
       </DetailSection>
 
       <div className="pt-4 border-t">
-        <ActionButtons report={report} onSuccess={onSuccess} />
+        <ActionButtons
+          report={report}
+          onSuccess={typeof onSuccess === "function" ? onSuccess : () => {}}
+        />
       </div>
     </div>
   );

--- a/loneleap-admin/components/reports/ChatReportTable.jsx
+++ b/loneleap-admin/components/reports/ChatReportTable.jsx
@@ -60,7 +60,12 @@ export default function ChatReportTable({ reports = [], onSelect }) {
                 </td>
                 <td className="px-4 py-2 whitespace-nowrap">
                   {report.reportedAt
-                    ? format(new Date(report.reportedAt), "yyyy.MM.dd")
+                    ? (() => {
+                        const date = new Date(report.reportedAt);
+                        return !isNaN(date.getTime())
+                          ? format(date, "yyyy.MM.dd")
+                          : "유효하지 않은 날짜";
+                      })()
                     : "날짜 없음"}
                 </td>
                 <td className="px-4 py-2">

--- a/loneleap-admin/lib/auth.js
+++ b/loneleap-admin/lib/auth.js
@@ -21,6 +21,16 @@ export async function verifyAdminToken(req, res) {
     return decoded;
   } catch (error) {
     console.error("[auth] verifyIdToken 실패:", error.code, error.message);
-    throw new Error("토큰 검증 실패");
+    if (error.code === "auth/id-token-expired") {
+      throw new Error("토큰이 만료되었습니다. 다시 로그인해 주세요.");
+    } else if (error.code === "auth/id-token-revoked") {
+      throw new Error("토큰이 취소되었습니다. 다시 로그인해 주세요.");
+    } else if (error.message === "관리자 권한이 없습니다.") {
+      throw error; // 이미 구체적인 오류 메시지가 있으므로 그대로 전달
+    } else {
+      throw new Error(
+        "토큰 검증에 실패했습니다: " + (error.code || "알 수 없는 오류")
+      );
+    }
   }
 }

--- a/loneleap-admin/pages/api/chatReports/deleteMessageWithReports.js
+++ b/loneleap-admin/pages/api/chatReports/deleteMessageWithReports.js
@@ -41,7 +41,9 @@ export default async function deleteMessageWithReports(req, res) {
 
       const messageSnap = await transaction.get(messageRef);
       if (!messageSnap.exists) {
-        throw new Error("삭제할 메시지가 존재하지 않습니다.");
+        const error = new Error("삭제할 메시지가 존재하지 않습니다.");
+        error.code = "not-found";
+        throw error;
       }
 
       transaction.delete(messageRef);

--- a/loneleap-admin/pages/api/chatReports/deleteMessageWithReports.js
+++ b/loneleap-admin/pages/api/chatReports/deleteMessageWithReports.js
@@ -10,7 +10,10 @@ export default async function deleteMessageWithReports(req, res) {
 
   // 관리자 인증
   try {
-    await verifyAdminToken(req);
+    const adminUser = await verifyAdminToken(req);
+    console.log(
+      `관리자 ${adminUser.email || adminUser.uid}가 메시지 삭제 시도`
+    );
   } catch (error) {
     console.error("관리자 인증 실패:", error.message);
     return res.status(401).json({ error: "관리자 권한이 필요합니다." });
@@ -48,6 +51,9 @@ export default async function deleteMessageWithReports(req, res) {
       });
     });
 
+    console.log(
+      `메시지 ID: ${messageId}, 방 ID: ${roomId}의 메시지 및 관련 신고 ${snapshot.size}개 삭제 완료`
+    );
     return res.status(200).json({ message: "메시지 및 관련 신고 삭제 완료" });
   } catch (err) {
     console.error("채팅 메시지 삭제 오류:", err);
@@ -63,7 +69,7 @@ export default async function deleteMessageWithReports(req, res) {
         error: "서버 오류로 메시지 삭제 실패",
         details: err.message,
         code: err.code,
-        stack: err.stack,
+        stack: process.env.NODE_ENV === "development" ? err.stack : undefined,
       });
     }
   }

--- a/loneleap-admin/pages/api/chatReports/dismissChatReport.js
+++ b/loneleap-admin/pages/api/chatReports/dismissChatReport.js
@@ -35,6 +35,9 @@ export default async function dismissChatReport(req, res) {
     return res.status(200).json({ message: "신고 삭제 완료" });
   } catch (err) {
     console.error("신고 삭제 오류:", err);
-    return res.status(500).json({ error: "서버 오류로 삭제 실패" });
+    return res.status(500).json({
+      error: "서버 오류로 삭제 실패",
+      details: process.env.NODE_ENV === "development" ? err.message : undefined,
+    });
   }
 }

--- a/loneleap-admin/pages/api/reviewReports/deleteReviewWithReports.js
+++ b/loneleap-admin/pages/api/reviewReports/deleteReviewWithReports.js
@@ -28,9 +28,19 @@ export default async function handler(req, res) {
       .where("reviewId", "==", reviewId);
     const snapshot = await reportsRef.get();
 
+    // 리뷰 문서 존재 여부 확인
+    const reviewRef = db.collection("reviews").doc(reviewId);
+    const reviewDoc = await reviewRef.get();
+
+    if (!reviewDoc.exists) {
+      return res
+        .status(404)
+        .json({ error: "삭제할 리뷰가 존재하지 않습니다." });
+    }
+
     // 5. 트랜잭션으로 리뷰 + 신고 일괄 삭제
     await db.runTransaction(async (transaction) => {
-      transaction.delete(db.collection("reviews").doc(reviewId));
+      transaction.delete(reviewRef);
       snapshot.docs.forEach((doc) => {
         transaction.delete(doc.ref);
       });


### PR DESCRIPTION
### 주요 수정 사항

### 관리자 인증 관련 개선
- verifyAdminToken 호출 후 인증된 관리자 정보 반환 및 활용
- 인증 실패 시 에러 메시지를 구체화하고 예외 유형별 분기 처리 추가
- 관리자 인증 토큰 검증 실패 시 401 → 명확한 오류 메시지 출력

### 메시지/리뷰 삭제 처리 안정화
- 채팅 메시지 삭제 시 not-found 에러에 대한 명확한 코드 처리
- 리뷰 삭제 API에 리뷰 존재 여부 확인 로직 추가 (doc.exists 체크)
- 삭제 성공 시 서버 콘솔에 로그 출력 추가

### 에러 응답 개선 (개발환경 전용)
- 서버 오류 응답(500) 시 error.message, error.stack, error.code를 상세 포함
- 클라이언트 디버깅에 도움되도록 개발환경에서만 응답 상세 정보 노출

### 프론트엔드 유효성 처리
- ActionButtons에서 onSuccess prop 유효성 검사 (typeof === 'function') 추가
- reportedAt 필드가 Invalid Date일 경우 graceful fallback 처리
- 날짜 포맷팅 시 null/undefined 대응 및 유효성 검사 로직 추가
