### PR TITLE
perf: 리뷰 신고 조회 성능 개선 및 접근성/정리 작업 포함

### DIFF
--- a/loneleap-admin/components/reports/ActionButtons.jsx
+++ b/loneleap-admin/components/reports/ActionButtons.jsx
@@ -47,7 +47,7 @@ export default function ActionButtons({ report, onSuccess }) {
       }
     } catch (err) {
       console.error("삭제 오류:", err);
-      alert("삭제 중 오류가 발생했습니다.");
+      alert("신고 삭제 중 오류가 발생했습니다.");
     } finally {
       setDeleting(false);
     }

--- a/loneleap-admin/components/reports/ChatReportDetail.jsx
+++ b/loneleap-admin/components/reports/ChatReportDetail.jsx
@@ -3,6 +3,7 @@
 import { format } from "date-fns";
 import ActionButtons from "../reports/ActionButtons";
 import DetailSection from "./DetailSection";
+import PropTypes from "prop-types";
 
 export default function ChatReportDetail({ report, onSuccess }) {
   if (!report) {
@@ -68,3 +69,15 @@ export default function ChatReportDetail({ report, onSuccess }) {
     </div>
   );
 }
+
+ChatReportDetail.propTypes = {
+  report: PropTypes.shape({
+    id: PropTypes.string,
+    messageText: PropTypes.string,
+    reason: PropTypes.string.isRequired,
+    reporterId: PropTypes.string,
+    reportedAt: PropTypes.string,
+    status: PropTypes.string,
+  }),
+  onSuccess: PropTypes.func,
+};

--- a/loneleap-admin/components/reports/ChatReportTable.jsx
+++ b/loneleap-admin/components/reports/ChatReportTable.jsx
@@ -44,6 +44,7 @@ export default function ChatReportTable({ reports = [], onSelect = () => {} }) {
                 tabIndex={0}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
                     onSelect(report);
                   }
                 }}


### PR DESCRIPTION
### 주요 변경사항

- **리뷰 신고 조회 성능 개선**
  - 기존 `doc.get()`을 사용한 N+1 방식 → 일괄 조회 (`Promise.all + Map`) 방식으로 개선
  - 대량의 리뷰가 있을 경우에도 성능 저하 없이 처리 가능

- **접근성 개선**
  - `keyDown` 이벤트 핸들러에 `preventDefault()` 추가
  - Enter 또는 Space 키 사용 시 스크롤/이동 방지

- **코드 명확화 및 일관성 개선**
  - `ChatReportDetail`에 `PropTypes` 정의 추가 → 컴포넌트 사용 시 타입 명확화
  - 신고 삭제 API의 에러 메시지 문구를 일관되게 통일

### 참고
- 신고/리뷰가 존재하지 않는 경우의 예외 처리도 함께 강화되었으며, 응답 메시지는 서버 로그 및 사용자 메시지 기준으로 구분 처리됩니다.
