### PR TITLE
feat: 마이페이지 일정/리뷰/채팅 탭 구현 및 카드 렌더링, 로그아웃 기능 이전 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,4 @@ firebase.json.bak
 
 # macOS/OS-specific
 Thumbs.db
->>>>>>> dev
-src/
 

--- a/loneleap-client/src/App.jsx
+++ b/loneleap-client/src/App.jsx
@@ -21,6 +21,7 @@ import ReviewDetailPage from "pages/Reviews/Detail";
 import CreateChatRoomPage from "pages/Chat/Create";
 import ChatRoomListPage from "pages/Chat/List";
 import ChatRoomDetailPage from "pages/Chat/Detail";
+import MyPage from "pages/MyPage";
 
 function App() {
   const dispatch = useDispatch();
@@ -66,6 +67,9 @@ function App() {
           <Route index element={<ChatRoomListPage />} />
           <Route path="create" element={<CreateChatRoomPage />}></Route>
           <Route path=":id" element={<ChatRoomDetailPage />} />
+        </Route>
+        <Route path="/mypage">
+          <Route index element={<MyPage />} />
         </Route>
       </Routes>
     </>

--- a/loneleap-client/src/components/Header.jsx
+++ b/loneleap-client/src/components/Header.jsx
@@ -39,6 +39,9 @@ export default function Header() {
           <Link to="/chat" className="hover:text-black">
             채팅 목록
           </Link>
+          <Link to="/mypage" className="hover:text-black">
+            마이페이지
+          </Link>
           <button
             onClick={handleLogout}
             className="text-red-500 hover:underline ml-2"

--- a/loneleap-client/src/components/Header.jsx
+++ b/loneleap-client/src/components/Header.jsx
@@ -1,25 +1,9 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { useSelector, useDispatch } from "react-redux";
-
-import { logout } from "services/auth";
-import { clearUser } from "store/userSlice";
+import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 export default function Header() {
   const user = useSelector((state) => state.user.user);
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-
-  const handleLogout = async () => {
-    try {
-      await logout(); // Firebase 로그아웃
-      dispatch(clearUser());
-      navigate("/");
-    } catch (error) {
-      console.error("로그아웃 실패:", error);
-      alert("로그아웃에 실패했습니다. 다시 시도해주세요.");
-    }
-  };
 
   return (
     <header className="bg-white px-6 py-4 border-b flex justify-between items-center shadow-sm">
@@ -42,12 +26,6 @@ export default function Header() {
           <Link to="/mypage" className="hover:text-black">
             마이페이지
           </Link>
-          <button
-            onClick={handleLogout}
-            className="text-red-500 hover:underline ml-2"
-          >
-            로그아웃
-          </button>
         </div>
       ) : (
         <div className="flex gap-4 text-sm text-gray-700">

--- a/loneleap-client/src/components/mypage/MyChatRoomCard.jsx
+++ b/loneleap-client/src/components/mypage/MyChatRoomCard.jsx
@@ -1,0 +1,42 @@
+// src/components/mypage/MyChatRoomCard.jsx
+import React from "react";
+
+export default function MyChatRoomCard({ room }) {
+  return (
+    <div className="bg-[#1f222c] rounded-2xl text-white shadow mb-6 p-6">
+      {/* 상단: 제목 + 생성일 */}
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-semibold">{room.name}</h3>
+        <span className="text-sm text-gray-400">
+          {room.createdAt?.toDate
+            ? room.createdAt.toDate().toLocaleDateString("ko-KR")
+            : "날짜 없음"}
+        </span>
+      </div>
+
+      {/* 설명 */}
+      {room.description && (
+        <p className="text-sm text-gray-400 line-clamp-2 mb-4">
+          {room.description}
+        </p>
+      )}
+
+      {/* 참여자 수 */}
+      {room.participants && (
+        <p className="text-sm text-gray-500 mb-4">
+          👥 {room.participants.length}명 참여 중
+        </p>
+      )}
+
+      {/* 하단 버튼 */}
+      <div className="flex justify-between items-center pt-4 border-t border-gray-700">
+        <button className="text-sm text-gray-300 hover:text-white transition">
+          참여하기
+        </button>
+        <button className="text-sm text-gray-300 hover:text-white transition">
+          신고
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/loneleap-client/src/components/mypage/MyChatRoomCard.jsx
+++ b/loneleap-client/src/components/mypage/MyChatRoomCard.jsx
@@ -1,7 +1,10 @@
 // src/components/mypage/MyChatRoomCard.jsx
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function MyChatRoomCard({ room }) {
+  const navigate = useNavigate(); // 훅 초기화
+
   return (
     <div className="bg-[#1f222c] rounded-2xl text-white shadow mb-6 p-6">
       {/* 상단: 제목 + 생성일 */}
@@ -30,7 +33,10 @@ export default function MyChatRoomCard({ room }) {
 
       {/* 하단 버튼 */}
       <div className="flex justify-between items-center pt-4 border-t border-gray-700">
-        <button className="text-sm text-gray-300 hover:text-white transition">
+        <button
+          onClick={() => navigate(`/chat/${room.id}`)} // 라우팅 연결
+          className="text-sm text-gray-300 hover:text-white transition"
+        >
           참여하기
         </button>
         <button className="text-sm text-gray-300 hover:text-white transition">

--- a/loneleap-client/src/components/mypage/MyItineraryCard.jsx
+++ b/loneleap-client/src/components/mypage/MyItineraryCard.jsx
@@ -1,7 +1,10 @@
 // src/components/mypage/MyItineraryCard.jsx
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function MyItineraryCard({ itinerary }) {
+  const navigate = useNavigate(); // 훅 초기화
+
   return (
     <div className="bg-[#1f222b] text-white rounded-xl p-5 shadow mb-6">
       <div className="flex justify-between items-center mb-2">
@@ -16,8 +19,15 @@ export default function MyItineraryCard({ itinerary }) {
       <div className="w-full h-40 bg-gray-700 rounded flex items-center justify-center text-sm text-gray-300">
         [여행지 이미지 자리]
       </div>
+
+      {/* 버튼 영역 */}
       <div className="flex justify-between items-center mt-4 text-sm">
-        <button className="text-gray-300 hover:text-white">상세 보기</button>
+        <button
+          onClick={() => navigate(`/itinerary/${itinerary.id}`)} // 상세 페이지 이동
+          className="text-gray-300 hover:text-white"
+        >
+          상세 보기
+        </button>
         <button className="text-gray-300 hover:text-white">문의</button>
       </div>
     </div>

--- a/loneleap-client/src/components/mypage/MyItineraryCard.jsx
+++ b/loneleap-client/src/components/mypage/MyItineraryCard.jsx
@@ -1,0 +1,25 @@
+// src/components/mypage/MyItineraryCard.jsx
+import React from "react";
+
+export default function MyItineraryCard({ itinerary }) {
+  return (
+    <div className="bg-[#1f222b] text-white rounded-xl p-5 shadow mb-6">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-bold">{itinerary.title}</h3>
+        <span className="text-sm bg-green-600 text-white px-2 py-1 rounded">
+          {itinerary.status}
+        </span>
+      </div>
+      <p className="text-sm text-gray-300 mb-3">
+        {itinerary.startDate} ~ {itinerary.endDate}
+      </p>
+      <div className="w-full h-40 bg-gray-700 rounded flex items-center justify-center text-sm text-gray-300">
+        [여행지 이미지 자리]
+      </div>
+      <div className="flex justify-between items-center mt-4 text-sm">
+        <button className="text-gray-300 hover:text-white">상세 보기</button>
+        <button className="text-gray-300 hover:text-white">문의</button>
+      </div>
+    </div>
+  );
+}

--- a/loneleap-client/src/components/mypage/MyReviewCard.jsx
+++ b/loneleap-client/src/components/mypage/MyReviewCard.jsx
@@ -1,0 +1,60 @@
+// src/components/mypage/MyReviewCard.jsx
+import React from "react";
+
+export default function MyReviewCard({ review }) {
+  return (
+    <div className="bg-[#1f222c] rounded-2xl overflow-hidden text-white shadow mb-6">
+      {/* 제목 + 날짜 */}
+      <div className="flex justify-between items-center px-6 pt-6">
+        <h3 className="text-lg font-semibold">
+          {review.title || "리뷰 제목 없음"}
+        </h3>
+        <span className="text-sm text-gray-400">
+          {new Date(review.createdAt).toLocaleDateString("ko-KR")}
+        </span>
+      </div>
+
+      {/* 목적지 & 별점 */}
+      <div className="px-6 mt-1 text-sm text-gray-400">
+        {review.destination && <div className="mb-1">{review.destination}</div>}
+        <div className="text-yellow-400 mb-2">
+          {"★".repeat(review.rating)}
+          <span className="text-gray-400 ml-1">{review.rating}점</span>
+        </div>
+      </div>
+
+      {/* 이미지 영역 - 카드 중앙 위치 */}
+      <div className="bg-[#2f3340] h-48 flex items-center justify-center mx-6 rounded-lg mb-4">
+        {review.imageUrl ? (
+          <img
+            src={review.imageUrl}
+            alt="리뷰 이미지"
+            className="w-full h-48 object-cover rounded-lg"
+          />
+        ) : (
+          <span className="text-gray-400">[리뷰 이미지 자리]</span>
+        )}
+      </div>
+
+      {/* 본문 내용 */}
+      <div className="px-6 text-sm text-gray-300 leading-relaxed mb-4 whitespace-pre-wrap">
+        {review.content}
+        {review.reported && (
+          <div className="mt-2 text-xs text-red-500 font-medium">
+            🚨 신고된 리뷰입니다
+          </div>
+        )}
+      </div>
+
+      {/* 하단 버튼 */}
+      <div className="flex justify-between items-center px-6 py-4 border-t border-gray-700">
+        <button className="text-sm text-gray-300 hover:text-white transition">
+          상세 보기
+        </button>
+        <button className="text-sm text-gray-300 hover:text-white transition">
+          문의
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/loneleap-client/src/components/mypage/MyReviewCard.jsx
+++ b/loneleap-client/src/components/mypage/MyReviewCard.jsx
@@ -1,7 +1,10 @@
 // src/components/mypage/MyReviewCard.jsx
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function MyReviewCard({ review }) {
+  const navigate = useNavigate(); // 훅 사용
+
   return (
     <div className="bg-[#1f222c] rounded-2xl overflow-hidden text-white shadow mb-6">
       {/* 제목 + 날짜 */}
@@ -23,7 +26,7 @@ export default function MyReviewCard({ review }) {
         </div>
       </div>
 
-      {/* 이미지 영역 - 카드 중앙 위치 */}
+      {/* 이미지 */}
       <div className="bg-[#2f3340] h-48 flex items-center justify-center mx-6 rounded-lg mb-4">
         {review.imageUrl ? (
           <img
@@ -36,7 +39,7 @@ export default function MyReviewCard({ review }) {
         )}
       </div>
 
-      {/* 본문 내용 */}
+      {/* 본문 */}
       <div className="px-6 text-sm text-gray-300 leading-relaxed mb-4 whitespace-pre-wrap">
         {review.content}
         {review.reported && (
@@ -48,7 +51,10 @@ export default function MyReviewCard({ review }) {
 
       {/* 하단 버튼 */}
       <div className="flex justify-between items-center px-6 py-4 border-t border-gray-700">
-        <button className="text-sm text-gray-300 hover:text-white transition">
+        <button
+          onClick={() => navigate(`/reviews/${review.id}`)} // 상세 페이지로 이동
+          className="text-sm text-gray-300 hover:text-white transition"
+        >
           상세 보기
         </button>
         <button className="text-sm text-gray-300 hover:text-white transition">

--- a/loneleap-client/src/components/mypage/ProfileSection.jsx
+++ b/loneleap-client/src/components/mypage/ProfileSection.jsx
@@ -1,0 +1,26 @@
+// src/components/mypage/ProfileSection.jsx
+import React from "react";
+
+export default function ProfileSection({ user }) {
+  return (
+    <div className="bg-gradient-to-b from-[#1f2937] to-[#111827] py-12 text-center">
+      <img
+        src="/user-avatar.svg" // 이미지 경로에 맞게 수정
+        alt="프로필 이미지"
+        className="w-24 h-24 rounded-full mx-auto border-2 border-white mb-4"
+      />
+      <h1 className="text-2xl font-semibold">
+        {user?.displayName || "닉네임"}
+      </h1>
+      <p className="text-sm text-gray-300 mb-4">Premium Member</p>
+      <div className="flex justify-center gap-4">
+        <button className="px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
+          프로필 수정
+        </button>
+        <button className="px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
+          설정
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/loneleap-client/src/components/mypage/ProfileSection.jsx
+++ b/loneleap-client/src/components/mypage/ProfileSection.jsx
@@ -1,11 +1,29 @@
 // src/components/mypage/ProfileSection.jsx
 import React from "react";
+import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import { logout } from "services/auth";
+import { clearUser } from "store/userSlice";
 
 export default function ProfileSection({ user }) {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      await logout(); // Firebase 로그아웃
+      dispatch(clearUser()); // Redux 상태 초기화
+      navigate("/"); // 홈으로 이동
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+      alert("로그아웃에 실패했습니다.");
+    }
+  };
+
   return (
     <div className="bg-gradient-to-b from-[#1f2937] to-[#111827] py-12 text-center">
       <img
-        src="/user-avatar.svg" // 이미지 경로에 맞게 수정
+        src="/user-avatar.svg"
         alt="프로필 이미지"
         className="w-24 h-24 rounded-full mx-auto border-2 border-white mb-4"
       />
@@ -13,12 +31,20 @@ export default function ProfileSection({ user }) {
         {user?.displayName || "닉네임"}
       </h1>
       <p className="text-sm text-gray-300 mb-4">Premium Member</p>
-      <div className="flex justify-center gap-4">
-        <button className="px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
+
+      {/* 버튼 그룹 */}
+      <div className="flex justify-center gap-4 flex-wrap">
+        <button className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
           프로필 수정
         </button>
-        <button className="px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
+        <button className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition">
           설정
+        </button>
+        <button
+          onClick={handleLogout}
+          className="min-w-[100px] px-4 py-2 border border-white text-red-500 rounded hover:bg-red-500 hover:text-white transition"
+        >
+          로그아웃
         </button>
       </div>
     </div>

--- a/loneleap-client/src/components/mypage/ProfileSection.jsx
+++ b/loneleap-client/src/components/mypage/ProfileSection.jsx
@@ -28,7 +28,7 @@ export default function ProfileSection({ user }) {
         className="w-24 h-24 rounded-full mx-auto border-2 border-white mb-4"
       />
       <h1 className="text-2xl font-semibold">
-        {user?.displayName || "닉네임"}
+        {user?.displayName || user?.email || "닉네임 없음"}
       </h1>
       <p className="text-sm text-gray-300 mb-4">Premium Member</p>
 

--- a/loneleap-client/src/components/mypage/SectionTabs.jsx
+++ b/loneleap-client/src/components/mypage/SectionTabs.jsx
@@ -1,0 +1,30 @@
+// src/components/mypage/SectionTabs.jsx
+import React from "react";
+
+export default function SectionTabs({ activeTab, setActiveTab }) {
+  const tabs = [
+    { key: "itinerary", label: "내 일정" },
+    { key: "review", label: "내 리뷰" },
+    { key: "chat", label: "채팅방" },
+  ];
+
+  return (
+    <div className="bg-[#f8f9fa] border-b border-gray-300">
+      <div className="max-w-5xl mx-auto px-6 pt-6 pb-2 flex justify-start gap-12">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className={`pb-2 text-base transition-all ${
+              activeTab === tab.key
+                ? "text-black font-semibold border-b-2 border-black"
+                : "text-gray-400 hover:text-black border-b-2 border-transparent"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/loneleap-client/src/pages/MyPage.jsx
+++ b/loneleap-client/src/pages/MyPage.jsx
@@ -1,20 +1,37 @@
 // src/pages/MyPage.jsx
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
-import ProfileSection from "../components/mypage/ProfileSection";
-import SectionTabs from "../components/mypage/SectionTabs";
-import EmptyState from "../components/EmptyState";
+import ProfileSection from "components/mypage/ProfileSection";
+import SectionTabs from "components/mypage/SectionTabs";
+import EmptyState from "components/EmptyState";
+
+import MyItineraryCard from "components/mypage/MyItineraryCard";
+import MyReviewCard from "components/mypage/MyReviewCard";
+import MyChatRoomCard from "components/mypage/MyChatRoomCard";
+
+import { useMyItineraries } from "services/queries/useMyItineraries";
+import { useMyReviews } from "services/queries/useMyReviews";
+import { useMyChatRooms } from "services/queries/useMyChatRooms";
 
 export default function MyPage() {
   const user = useSelector((state) => state.user.user);
   const [activeTab, setActiveTab] = useState("itinerary"); // 기본: 내 일정
 
-  const renderContent = () => {
-    const myItineraries = [];
-    const myReviews = [];
-    const myChats = [];
+  const { data: myItineraries = [], isLoading: isItineraryLoading } =
+    useMyItineraries(user?.uid);
+  const { data: myReviews = [], isLoading: isReviewLoading } = useMyReviews(
+    user?.uid
+  );
+  const { data: myChatRooms = [], isLoading: isChatLoading } = useMyChatRooms(
+    user?.uid
+  );
 
+  const renderContent = () => {
     if (activeTab === "itinerary") {
+      if (isItineraryLoading) {
+        return <div className="text-gray-400">불러오는 중...</div>;
+      }
+
       return myItineraries.length === 0 ? (
         <EmptyState
           icon="📅"
@@ -22,11 +39,19 @@ export default function MyPage() {
           description="새로운 일정을 추가해 LoneLeap 여정을 시작해보세요."
         />
       ) : (
-        <div>[일정 카드 리스트]</div>
+        <div>
+          {myItineraries.map((item) => (
+            <MyItineraryCard key={item.id} itinerary={item} />
+          ))}
+        </div>
       );
     }
 
     if (activeTab === "review") {
+      if (isReviewLoading) {
+        return <div className="text-gray-400">불러오는 중...</div>;
+      }
+
       return myReviews.length === 0 ? (
         <EmptyState
           icon="📝"
@@ -34,22 +59,33 @@ export default function MyPage() {
           description="여행지를 다녀오셨다면, 리뷰를 공유해보세요."
         />
       ) : (
-        <div>[리뷰 카드 리스트]</div>
+        <div>
+          {myReviews.map((review) => (
+            <MyReviewCard key={review.id} review={review} />
+          ))}
+        </div>
       );
     }
 
     if (activeTab === "chat") {
-      return myChats.length === 0 ? (
+      if (isChatLoading) {
+        return <div className="text-gray-400">불러오는 중...</div>;
+      }
+
+      return myChatRooms.length === 0 ? (
         <EmptyState
           icon="💬"
           title="참여한 채팅방이 없습니다"
           description="함께 소통할 채팅방에 참여해보세요."
         />
       ) : (
-        <div>[채팅방 카드 리스트]</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {myChatRooms.map((room) => (
+            <MyChatRoomCard key={room.id} room={room} />
+          ))}
+        </div>
       );
     }
-
     return null;
   };
 

--- a/loneleap-client/src/pages/MyPage.jsx
+++ b/loneleap-client/src/pages/MyPage.jsx
@@ -1,0 +1,71 @@
+// src/pages/MyPage.jsx
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import ProfileSection from "../components/mypage/ProfileSection";
+import SectionTabs from "../components/mypage/SectionTabs";
+import EmptyState from "../components/EmptyState";
+
+export default function MyPage() {
+  const user = useSelector((state) => state.user.user);
+  const [activeTab, setActiveTab] = useState("itinerary"); // 기본: 내 일정
+
+  const renderContent = () => {
+    const myItineraries = [];
+    const myReviews = [];
+    const myChats = [];
+
+    if (activeTab === "itinerary") {
+      return myItineraries.length === 0 ? (
+        <EmptyState
+          icon="📅"
+          title="작성한 일정이 없습니다"
+          description="새로운 일정을 추가해 LoneLeap 여정을 시작해보세요."
+        />
+      ) : (
+        <div>[일정 카드 리스트]</div>
+      );
+    }
+
+    if (activeTab === "review") {
+      return myReviews.length === 0 ? (
+        <EmptyState
+          icon="📝"
+          title="작성한 리뷰가 없습니다"
+          description="여행지를 다녀오셨다면, 리뷰를 공유해보세요."
+        />
+      ) : (
+        <div>[리뷰 카드 리스트]</div>
+      );
+    }
+
+    if (activeTab === "chat") {
+      return myChats.length === 0 ? (
+        <EmptyState
+          icon="💬"
+          title="참여한 채팅방이 없습니다"
+          description="함께 소통할 채팅방에 참여해보세요."
+        />
+      ) : (
+        <div>[채팅방 카드 리스트]</div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="min-h-screen bg-white text-black">
+      {/* 상단: 어두운 그라디언트 배경 */}
+      <section className="bg-gradient-to-b from-[#1c1f2a] to-[#2d3243] text-white">
+        <ProfileSection user={user} />
+      </section>
+
+      {/* 탭 + 콘텐츠: 밝은 배경 */}
+      <section className="bg-[#f8f9fa] min-h-screen">
+        <SectionTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+
+        <div className="max-w-5xl mx-auto px-6 py-10">{renderContent()}</div>
+      </section>
+    </div>
+  );
+}

--- a/loneleap-client/src/services/queries/useMyChatRooms.js
+++ b/loneleap-client/src/services/queries/useMyChatRooms.js
@@ -1,0 +1,23 @@
+// src/services/queries/useMyChatRooms.js
+import { useQuery } from "@tanstack/react-query";
+import { collection, getDocs, query, where, orderBy } from "firebase/firestore";
+import { db } from "../firebase";
+
+export const useMyChatRooms = (uid) => {
+  return useQuery({
+    queryKey: ["myChatRooms", uid],
+    enabled: !!uid,
+    queryFn: async () => {
+      const q = query(
+        collection(db, "chatRooms"),
+        where("participants", "array-contains", uid),
+        orderBy("createdAt", "desc")
+      );
+      const snapshot = await getDocs(q);
+      return snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+    },
+  });
+};

--- a/loneleap-client/src/services/queries/useMyReviews.js
+++ b/loneleap-client/src/services/queries/useMyReviews.js
@@ -1,0 +1,37 @@
+// src/services/queries/useMyReviews.js
+import { useQuery } from "@tanstack/react-query";
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit,
+} from "firebase/firestore";
+import { db } from "../firebase";
+
+export const useMyReviews = (uid) => {
+  return useQuery({
+    queryKey: ["myReviews", uid],
+    enabled: !!uid,
+    queryFn: async () => {
+      const q = query(
+        collection(db, "reviews"),
+        where("authorId", "==", uid),
+        orderBy("createdAt", "desc"),
+        limit(20)
+      );
+
+      const snapshot = await getDocs(q);
+      return snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      }));
+    },
+    onError: (error) => {
+      console.error("내 리뷰 조회 중 오류:", error);
+    },
+  });
+};


### PR DESCRIPTION
### 주요 변경 사항

1. 마이페이지 탭 구조 구현
   - 내 일정 / 내 리뷰 / 참여 채팅방 탭 전환 UI 구현 (SectionTabs)
   - 선택된 탭에 따라 콘텐츠 조건부 렌더링

2. 일정, 리뷰, 채팅방 데이터 연동
   - useMyItineraries, useMyReviews, useMyChatRooms 커스텀 훅 구현
   - 로그인한 유저 기준으로 Firestore 데이터 필터링 조회
   - 각 항목별 EmptyState 처리 추가

3. 카드 컴포넌트 렌더링
   - MyItineraryCard, MyReviewCard, MyChatRoomCard 컴포넌트 추가
   - 각 카드 하단에 상세 보기 버튼 연결 (`/itinerary/:id`, `/reviews/:id`, `/chat/:id`)

4. 로그아웃 기능 마이페이지로 이동
   - 기존 Header 내 로그아웃 버튼 제거
   - ProfileSection 내 우측 상단 버튼으로 대체
   - Firebase + Redux 상태 초기화 처리 유지

5. 프로필 섹션 UI 개선
   - 사용자 프로필 이미지, 닉네임(email 대체), 버튼 스타일 통일
   - 버튼 정렬 및 높이 이슈 해결 (leading, min-w 등 Tailwind 적용)

### 참고 사항
- 프로필 이미지 및 멤버등급을 향후 커스터마이징 가능하도록 수정할 예정