### PR TITLE
refactor: 코드 전반 구조 개선 및 쿼리/컴포넌트 안정성 리팩토링

### DIFF
--- a/loneleap-client/jsconfig.json
+++ b/loneleap-client/jsconfig.json
@@ -6,7 +6,8 @@
       "pages/*": ["pages/*"],
       "services/*": ["services/*"],
       "store/*": ["store/*"],
-      "hooks/*": ["hooks/*"]
+      "hooks/*": ["hooks/*"],
+      "utils/*": ["utils/*"]
     }
   },
   "include": ["src"]

--- a/loneleap-client/src/components/Review/ReviewForm.jsx
+++ b/loneleap-client/src/components/Review/ReviewForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import RatingInput from "./RatingInput";
+import { useNavigate } from "react-router-dom";
 
 const MAX_CONTENT_LENGTH = 1000;
 
@@ -14,6 +15,8 @@ export default function ReviewForm({ initialData, onSubmit, isLoading }) {
 
   const [errors, setErrors] = useState({});
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     let objectUrl;
@@ -186,8 +189,7 @@ export default function ReviewForm({ initialData, onSubmit, isLoading }) {
         <button
           type="button"
           onClick={() => {
-            // 라우터 사용 예시
-            window.location.href = "/reviews"; // 또는 React Router의 navigate 사용
+            navigate("/reviews");
           }}
           className="w-1/3 bg-gray-200 text-gray-800 font-semibold py-3 rounded-md hover:bg-gray-300 transition"
         >

--- a/loneleap-client/src/components/chat/ChatMessage.jsx
+++ b/loneleap-client/src/components/chat/ChatMessage.jsx
@@ -15,6 +15,7 @@ export default function ChatMessage({ message }) {
     roomId,
     createdAt,
   } = message;
+
   const isMine = senderId === user?.uid;
   const [openReportModal, setOpenReportModal] = useState(false);
 
@@ -26,9 +27,8 @@ export default function ChatMessage({ message }) {
     >
       <div className="max-w-xs">
         {/* 상대방 이름 표시 */}
-        {!isMine && (
-          <p className="text-xs text-gray-500 mb-1">{message.senderName}</p>
-        )}
+        {!isMine && <p className="text-xs text-gray-500 mb-1">{senderName}</p>}
+
         {/* 말풍선 */}
         <div
           className={`px-4 py-2 rounded-xl text-sm ${
@@ -37,7 +37,7 @@ export default function ChatMessage({ message }) {
               : "bg-gray-100 text-gray-900 rounded-bl-none"
           }`}
         >
-          {message.message}
+          {messageText}
         </div>
 
         {/* 신고 버튼 (본인 제외) */}
@@ -55,22 +55,18 @@ export default function ChatMessage({ message }) {
 
         {/* 시간 표시 */}
         <p className="text-[10px] text-gray-400 mt-1 text-right">
-          {message.createdAt
-            ? typeof message.createdAt.toDate === "function"
-              ? formatRelative(message.createdAt.toDate(), new Date(), {
-                  locale: ko,
-                })
-              : formatRelative(new Date(message.createdAt), new Date(), {
-                  locale: ko,
-                })
+          {createdAt
+            ? typeof createdAt.toDate === "function"
+              ? formatRelative(createdAt.toDate(), new Date(), { locale: ko })
+              : formatRelative(new Date(createdAt), new Date(), { locale: ko })
             : "시간 정보 없음"}
         </p>
 
         {/* 신고 모달 조건부 렌더링 */}
         {openReportModal && (
           <ReportModal
-            messageId={message.id}
-            roomId={message.roomId}
+            messageId={id}
+            roomId={roomId}
             onClose={() => setOpenReportModal(false)}
           />
         )}

--- a/loneleap-client/src/components/mypage/MyItineraryCard.jsx
+++ b/loneleap-client/src/components/mypage/MyItineraryCard.jsx
@@ -4,30 +4,41 @@ import { useNavigate } from "react-router-dom";
 
 export default function MyItineraryCard({ itinerary }) {
   const navigate = useNavigate();
+  const { id, title, status, startDate, endDate, imageUrl } = itinerary;
+
   return (
     <div className="bg-[#1f222b] text-white rounded-xl p-5 shadow mb-6">
       <div className="flex justify-between items-center mb-2">
-        <h3 className="text-lg font-bold">{itinerary.title}</h3>
+        <h3 className="text-lg font-bold">{title}</h3>
         <span className="text-sm bg-green-600 text-white px-2 py-1 rounded">
-          {itinerary.status}
+          {status}
         </span>
       </div>
       <p className="text-sm text-gray-300 mb-3">
-        {itinerary.startDate} ~ {itinerary.endDate}
+        {startDate} ~ {endDate}
       </p>
       <div className="w-full h-40 bg-gray-700 rounded flex items-center justify-center text-sm text-gray-300">
-        [여행지 이미지 자리]
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={title}
+            className="w-full h-full object-cover rounded"
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full w-full">
+            <span>이미지가 없습니다</span>
+          </div>
+        )}
       </div>
 
       {/* 버튼 영역 */}
       <div className="flex justify-between items-center mt-4 text-sm">
         <button
-          onClick={() => navigate(`/itinerary/${itinerary.id}`)}
+          onClick={() => navigate(`/itinerary/${id}`)}
           className="text-gray-300 hover:text-white"
         >
           상세 보기
         </button>
-        <button className="text-gray-300 hover:text-white">문의</button>
       </div>
     </div>
   );

--- a/loneleap-client/src/components/mypage/MyReviewCard.jsx
+++ b/loneleap-client/src/components/mypage/MyReviewCard.jsx
@@ -2,46 +2,68 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
-export default function MyReviewCard({ review }) {
+export default function MyReviewCard({ review = {} }) {
   const navigate = useNavigate();
+  // 객체 디스트럭처링 및 기본값 설정
+  const {
+    id = "",
+    title = "",
+    destination = "",
+    content = "",
+    rating = 0,
+    createdAt = new Date(),
+    imageUrl = "",
+    reported = false,
+  } = review;
+
   return (
     <div className="bg-[#1f222c] rounded-2xl overflow-hidden text-white shadow mb-6">
       {/* 제목 + 날짜 */}
       <div className="flex justify-between items-center px-6 pt-6">
-        <h3 className="text-lg font-semibold">
-          {review.title || "리뷰 제목 없음"}
-        </h3>
+        <h3 className="text-lg font-semibold">{title || "리뷰 제목 없음"}</h3>
         <span className="text-sm text-gray-400">
-          {new Date(review.createdAt).toLocaleDateString("ko-KR")}
+          {new Date(createdAt).toLocaleDateString("ko-KR")}
         </span>
       </div>
 
       {/* 목적지 & 별점 */}
       <div className="px-6 mt-1 text-sm text-gray-400">
-        {review.destination && <div className="mb-1">{review.destination}</div>}
+        {destination && <div className="mb-1">{destination}</div>}
         <div className="text-yellow-400 mb-2">
-          {"★".repeat(review.rating)}
-          <span className="text-gray-400 ml-1">{review.rating}점</span>
+          {"★".repeat(rating)}
+          <span className="text-gray-400 ml-1">{rating}점</span>
         </div>
       </div>
 
       {/* 이미지 */}
       <div className="bg-[#2f3340] h-48 flex items-center justify-center mx-6 rounded-lg mb-4">
-        {review.imageUrl ? (
+        {imageUrl ? (
           <img
-            src={review.imageUrl}
+            src={imageUrl}
             alt="리뷰 이미지"
             className="w-full h-48 object-cover rounded-lg"
           />
         ) : (
-          <span className="text-gray-400">[리뷰 이미지 자리]</span>
+          <span className="text-gray-400">
+            {imageUrl ? (
+              <img
+                src={imageUrl}
+                alt={title}
+                className="w-full h-full object-cover rounded"
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full w-full">
+                <span>이미지가 없습니다</span>
+              </div>
+            )}
+          </span>
         )}
       </div>
 
       {/* 본문 */}
       <div className="px-6 text-sm text-gray-300 leading-relaxed mb-4 whitespace-pre-wrap">
-        {review.content}
-        {review.reported && (
+        {content}
+        {reported && (
           <div className="mt-2 text-xs text-red-500 font-medium">
             🚨 신고된 리뷰입니다
           </div>
@@ -51,13 +73,10 @@ export default function MyReviewCard({ review }) {
       {/* 하단 버튼 */}
       <div className="flex justify-between items-center px-6 py-4 border-t border-gray-700">
         <button
-          onClick={() => navigate(`/reviews/${review.id}`)}
+          onClick={() => navigate(`/reviews/${id}`)}
           className="text-sm text-gray-300 hover:text-white transition"
         >
           상세 보기
-        </button>
-        <button className="text-sm text-gray-300 hover:text-white transition">
-          문의
         </button>
       </div>
     </div>

--- a/loneleap-client/src/components/mypage/ProfileSection.jsx
+++ b/loneleap-client/src/components/mypage/ProfileSection.jsx
@@ -6,7 +6,7 @@ import { logout } from "services/auth";
 import { clearUser } from "store/userSlice";
 import PropTypes from "prop-types";
 
-export default function ProfileSection({ user }) {
+export default function ProfileSection({ user = null }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -57,10 +57,5 @@ ProfileSection.propTypes = {
     displayName: PropTypes.string,
     email: PropTypes.string,
     photoURL: PropTypes.string,
-    // 기타 필요한 속성들...
   }),
-};
-
-ProfileSection.defaultProps = {
-  user: null,
 };

--- a/loneleap-client/src/pages/MyPage.jsx
+++ b/loneleap-client/src/pages/MyPage.jsx
@@ -27,65 +27,80 @@ export default function MyPage() {
   );
 
   const renderContent = () => {
-    if (activeTab === "itinerary") {
-      if (isItineraryLoading) {
+    const renderTabContent = (
+      isLoading,
+      items,
+      EmptyStateProps,
+      renderItems
+    ) => {
+      if (isLoading) {
         return <div className="text-gray-400">불러오는 중...</div>;
       }
 
-      return myItineraries.length === 0 ? (
-        <EmptyState
-          icon="📅"
-          title="작성한 일정이 없습니다"
-          description="새로운 일정을 추가해 LoneLeap 여정을 시작해보세요."
-        />
-      ) : (
-        <div>
-          {myItineraries.map((item) => (
-            <MyItineraryCard key={item.id} itinerary={item} />
-          ))}
-        </div>
+      if (!items || items.length === 0) {
+        return <EmptyState {...EmptyStateProps} />;
+      }
+
+      return renderItems(items);
+    };
+
+    if (activeTab === "itinerary") {
+      return renderTabContent(
+        isItineraryLoading,
+        myItineraries,
+        {
+          icon: "📅",
+          title: "작성한 일정이 없습니다",
+          description: "새로운 일정을 추가해 LoneLeap 여정을 시작해보세요.",
+        },
+        (items) => (
+          <div>
+            {items.map((item) => (
+              <MyItineraryCard key={item.id} itinerary={item} />
+            ))}
+          </div>
+        )
       );
     }
 
     if (activeTab === "review") {
-      if (isReviewLoading) {
-        return <div className="text-gray-400">불러오는 중...</div>;
-      }
-
-      return myReviews.length === 0 ? (
-        <EmptyState
-          icon="📝"
-          title="작성한 리뷰가 없습니다"
-          description="여행지를 다녀오셨다면, 리뷰를 공유해보세요."
-        />
-      ) : (
-        <div>
-          {myReviews.map((review) => (
-            <MyReviewCard key={review.id} review={review} />
-          ))}
-        </div>
+      return renderTabContent(
+        isReviewLoading,
+        myReviews,
+        {
+          icon: "📝",
+          title: "작성한 리뷰가 없습니다",
+          description: "여행지를 다녀오셨다면, 리뷰를 공유해보세요.",
+        },
+        (reviews) => (
+          <div>
+            {reviews.map((review) => (
+              <MyReviewCard key={review.id} review={review} />
+            ))}
+          </div>
+        )
       );
     }
 
     if (activeTab === "chat") {
-      if (isChatLoading) {
-        return <div className="text-gray-400">불러오는 중...</div>;
-      }
-
-      return myChatRooms.length === 0 ? (
-        <EmptyState
-          icon="💬"
-          title="참여한 채팅방이 없습니다"
-          description="함께 소통할 채팅방에 참여해보세요."
-        />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {myChatRooms.map((room) => (
-            <MyChatRoomCard key={room.id} room={room} />
-          ))}
-        </div>
+      return renderTabContent(
+        isChatLoading,
+        myChatRooms,
+        {
+          icon: "💬",
+          title: "참여한 채팅방이 없습니다",
+          description: "함께 소통할 채팅방에 참여해보세요.",
+        },
+        (rooms) => (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {rooms.map((room) => (
+              <MyChatRoomCard key={room.id} room={room} />
+            ))}
+          </div>
+        )
       );
     }
+
     return null;
   };
 

--- a/loneleap-client/src/pages/Reviews/Detail.jsx
+++ b/loneleap-client/src/pages/Reviews/Detail.jsx
@@ -4,6 +4,7 @@ import { useReviewDetail } from "services/queries/useReviewDetail";
 import LoadingSpinner from "components/LoadingSpinner";
 import NotFoundMessage from "components/NotFoundMessage";
 import ReportButton from "components/Review/ReportButton";
+import { formatDate } from "utils/formatDate";
 
 export default function ReviewDetailPage() {
   const { id } = useParams();
@@ -43,51 +44,7 @@ export default function ReviewDetailPage() {
           <span aria-label={`평점 ${rating}점`}>⭐ {rating}</span> ·{" "}
           {authorName}
         </p>
-        <p className="text-gray-400 text-xs mb-6">
-          {(() => {
-            if (!createdAt) return "날짜 없음";
-
-            try {
-              // Firestore Timestamp 처리
-              if (typeof createdAt.toDate === "function") {
-                return createdAt.toDate().toLocaleString("ko-KR", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              }
-
-              // Date 객체 처리
-              if (createdAt instanceof Date) {
-                return createdAt.toLocaleString("ko-KR", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              }
-
-              // ISO 문자열 처리
-              if (typeof createdAt === "string") {
-                return new Date(createdAt).toLocaleString("ko-KR", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              }
-
-              return "날짜 형식 오류";
-            } catch (error) {
-              console.error("날짜 형식 변환 오류:", error);
-              return "날짜 변환 오류";
-            }
-          })()}
-        </p>
+        <p className="text-gray-400 text-xs mb-6">{formatDate(createdAt)}</p>
       </header>
 
       <div className="mb-6">

--- a/loneleap-client/src/services/queries/useAddReview.js
+++ b/loneleap-client/src/services/queries/useAddReview.js
@@ -6,6 +6,13 @@ import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 
+/**
++ * 리뷰 추가 기능을 제공하는 커스텀 훅
++ * @param {Object} options - 훅 옵션
++ * @param {Function} options.onSuccessCallback - 리뷰 추가 성공 시 호출되는 콜백 함수
++ * @param {Function} options.onErrorCallback - 리뷰 추가 실패 시 호출되는 콜백 함수(에러 객체를 매개변수로 받음)
++ * @returns {Object} 리뷰 추가 관련 함수와 상태
++ */
 export default function useAddReview({
   onSuccessCallback = () => {},
   onErrorCallback = () => {},

--- a/loneleap-client/src/services/queries/useMyReviews.js
+++ b/loneleap-client/src/services/queries/useMyReviews.js
@@ -26,8 +26,8 @@ export const useMyReviews = (uid) => {
       return snapshot.docs.map((doc) => ({
         id: doc.id,
         ...doc.data(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+        createdAt: doc.data().createdAt ? doc.data().createdAt.toDate() : null,
+        updatedAt: doc.data().updatedAt ? doc.data().updatedAt.toDate() : null,
       }));
     },
     onError: (error) => {

--- a/loneleap-client/src/utils/formatDate.js
+++ b/loneleap-client/src/utils/formatDate.js
@@ -1,0 +1,34 @@
+// utils/formatDate.js
+export function formatDate(dateValue) {
+  if (!dateValue) return "날짜 없음";
+
+  const formatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  };
+
+  try {
+    // Firestore Timestamp 처리
+    if (typeof dateValue.toDate === "function") {
+      return dateValue.toDate().toLocaleString("ko-KR", formatOptions);
+    }
+
+    // Date 객체 처리
+    if (dateValue instanceof Date) {
+      return dateValue.toLocaleString("ko-KR", formatOptions);
+    }
+
+    // ISO 문자열 처리
+    if (typeof dateValue === "string") {
+      return new Date(dateValue).toLocaleString("ko-KR", formatOptions);
+    }
+
+    return "날짜 형식 오류";
+  } catch (error) {
+    console.error("날짜 형식 변환 오류:", error);
+    return "날짜 변환 오류";
+  }
+}

--- a/loneleap-client/vite.config.js
+++ b/loneleap-client/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
       services: path.resolve(__dirname, "src/services"),
       store: path.resolve(__dirname, "src/store"),
       hooks: path.resolve(__dirname, "src/hooks"),
+      utils: path.resolve(__dirname, "src/utils"),
     },
   },
 });


### PR DESCRIPTION
- 날짜 형식 처리 유틸 함수 `formatDate`로 분리
- Vite 및 jsconfig에 절대 경로(alias) 설정 추가
- useChatRooms 훅에 limit, 정렬, 필터링 파라미터 추가 및 queryKey 개선
- ChatMessage 컴포넌트에서 message 객체 구조분해 적용
- useAddReview 훅에 콜백 옵션 파라미터 및 JSDoc 주석 추가
- useMyReviews 훅 내 Timestamp toDate() 조건 분리
- ProfileSection 기본값을 defaultProps 대신 함수 파라미터로 처리
- MyItineraryCard 구조분해 할당 적용으로 가독성 개선
- 마이페이지 renderContent 내 로딩/빈 상태 UI 패턴 추상화
- MyReviewCard 내 목적지, 별점 렌더링 개선 및 props 구조화
- window.location → React Router `navigate`로 변경
- 일정/리뷰 카드 이미지에 플레이스홀더 및 fallback 처리
- 리뷰 제목 기본값 처리 및 문의 버튼 제거