### PR TITLE
feat: LoneLeap 메인 푸터 영역 구성

### DIFF
--- a/loneleap-client/src/components/Footer.jsx
+++ b/loneleap-client/src/components/Footer.jsx
@@ -1,3 +1,47 @@
+// src/components/Footer.jsx
+
 export default function Footer() {
-  return;
+  return (
+    <footer className="bg-gray-900 text-gray-300 py-12 px-6 text-sm">
+      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-8">
+        <div>
+          <h3 className="font-semibold mb-2 text-white">LoneLeap</h3>
+          <p className="text-gray-400">
+            혼자 떠나는 여행을 위한 감성 플랫폼
+            <br />© {new Date().getFullYear()} LoneLeap
+          </p>
+        </div>
+
+        <div>
+          <h4 className="font-semibold mb-2">여행지</h4>
+          <ul className="space-y-1">
+            <li>제주도</li>
+            <li>부산</li>
+            <li>경주</li>
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="font-semibold mb-2">고객 지원</h4>
+          <ul className="space-y-1">
+            <li>자주 묻는 질문</li>
+            <li>문의하기</li>
+            <li>이용약관</li>
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="font-semibold mb-2">뉴스레터</h4>
+          <input
+            type="email"
+            placeholder="이메일 주소"
+            className="w-full px-3 py-2 rounded bg-gray-800 text-white placeholder-gray-400"
+          />
+          <button className="mt-2 w-full bg-white text-gray-900 font-semibold py-2 rounded hover:bg-gray-100 transition">
+            구독
+          </button>
+        </div>
+      </div>
+    </footer>
+  );
 }


### PR DESCRIPTION
## 주요 변경 사항

LoneLeap 메인 페이지 하단에 공통 Footer UI를 구성했습니다.  
MVP 버전에 맞게 미니멀한 레이아웃으로 구현했으며,  
각 섹션은 명확한 분류와 기본 콘텐츠로 구성되어 있습니다.

## 구현 내용

### Footer 구성
- 브랜드 소개 및 저작권 표기
- 추천 여행지 간단한 링크 리스트
- 고객 지원 섹션 (문의, 약관 등)
- 뉴스레터 구독 입력 UI (기능은 추후 연결 예정)

### 스타일
- 어두운 톤의 배경 (`bg-gray-900`)
- 텍스트 대비 강조 (`text-gray-300`, `text-white`)
- 반응형 1~4열 그리드 구성 (Tailwind 기반)

## 테스트 체크

- [x] App 전체에서 하단에 Footer 정상 출력
- [x] 메인 페이지와 감성 톤 통일됨
- [x] 반응형에서도 UI 깨짐 없이 유지됨
- [x] 뉴스레터 입력란 및 버튼 UI 정상 렌더링

## 적용 위치
- `App.jsx` 내 공통 Footer 위치 유지
- 컴포넌트: `components/Footer.jsx`