### PR TITLE
feat: 회원가입 시 Firestore users 컬렉션에 사용자 정보 자동 저장

### DIFF
--- a/loneleap-client/src/services/auth.js
+++ b/loneleap-client/src/services/auth.js
@@ -9,19 +9,29 @@ import {
   updateProfile,
 } from "firebase/auth";
 import { auth } from "./firebase";
+import { db } from "./firestore";
+import { doc, setDoc } from "firebase/firestore";
 
 // 회원가입
 export const signUp = async (email, password, displayName) => {
   const result = await createUserWithEmailAndPassword(auth, email, password);
 
-  // displayName 설정
   try {
+    // 🔹 displayName 설정
     if (displayName && displayName.trim() !== "") {
       await updateProfile(result.user, { displayName });
     }
+
+    // 🔹 Firestore에 사용자 정보 추가
+    const userRef = doc(db, "users", result.user.uid);
+    await setDoc(userRef, {
+      email: result.user.email,
+      displayName: displayName || "", // 없을 수도 있으니까
+      createdAt: new Date().toISOString(),
+    });
   } catch (error) {
-    console.error("프로필 업데이트 중 오류 발생:", error);
-    // 사용자에게 프로필 업데이트 실패를 알릴 수 있는 방법 고려
+    console.error("회원가입 후 Firestore 저장 실패:", error);
+    // 필요시 예외 처리
   }
 
   return result;

--- a/loneleap-client/src/services/firestore.js
+++ b/loneleap-client/src/services/firestore.js
@@ -130,3 +130,5 @@ export const deleteItinerary = async (id) => {
     throw error;
   }
 };
+
+export { db };


### PR DESCRIPTION
Firebase Authentication 기반 이메일/비밀번호 회원가입 시,
사용자의 이메일과 UID를 users 컬렉션에 자동 저장하는 로직을 추가했습니다.

이를 통해 관리자 페이지에서 신고자 이메일 조회가 가능하도록 기반 데이터를 마련합니다.

### 주요 변경 사항
- auth.js
- 회원가입 성공 시 addDoc()을 통해 users/{uid} 문서 자동 생성
- 저장되는 필드: email, createdAt, uid

### 참고 사항
- 기존 회원 데이터에는 반영되지 않음 (별도 마이그레이션 필요)
- 관리자 페이지에서 사용자 이메일 확인 기능과 연동됨
