### PR TITLE
chore: Firestore 및 Storage 보안 규칙 파일 추가 및 배포 설정 적용

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,11 @@ service cloud.firestore {
       allow create: if isSignedIn();
     }
 
+    match /users/{userId} {
+    allow read, write: if isSignedIn() && isOwner(userId);
+    allow create: if isSignedIn();
+    }
+
     match /chatRooms/{roomId} {
       allow read: if isSignedIn();
       allow write: if isSignedIn() && request.auth.uid in request.resource.data.participants;

--- a/storage.rules
+++ b/storage.rules
@@ -2,20 +2,25 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
 
-    // 기본 접근 - 인증된 사용자만 읽기 가능
-    match /{allPaths=**} {
-      allow read: if request.auth != null;
-    }
-
     // 일정 관련 파일 - 사용자 본인만 접근 가능
     match /itineraries/{userId}/{itineraryId}/{fileName} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // 관리자만 쓰기 허용 (예: 추천 여행지 이미지 업로드 등)
+    // 리뷰 이미지 업로드 - 로그인된 유저 모두 가능
+    match /reviews/{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+
+    // 관리자만 업로드 가능
     match /admin/{allPaths=**} {
       allow write: if request.auth != null &&
         firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+
+    // 기본: 인증된 유저만 읽기 허용
+    match /{allPaths=**} {
+      allow read: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
- firestore.rules: 사용자 인증 기반 문서 접근 제한 규칙 정의
- storage.rules: 리뷰/일정 이미지 업로드 경로 권한 설정
- firebase.json에 rules 경로 연동
- firebase deploy --only firestore:rules,storage 기준 적용