### PR TITLE
feat: 리뷰 좋아요 기능 구현 및 실시간 UI 반영 완료

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     function isAdmin() {
-    return exists(/databases/$(database)/documents/admin/$(request.auth.token.email));
+      return exists(/databases/$(database)/documents/admin/$(request.auth.token.email));
     }
 
     function isSignedIn() {
@@ -15,7 +15,7 @@ service cloud.firestore {
     }
 
     match /admin/{email} {
-    allow read, write: if false;
+      allow read, write: if false;
     }
 
     match /itineraries/{itineraryId} {
@@ -25,9 +25,21 @@ service cloud.firestore {
 
     match /reviews/{reviewId} {
       allow read: if true;
+
+      // 리뷰 생성자는 전체 write 가능
       allow write: if isSignedIn() && isOwner(resource.data.authorId);
+
+      // likesCount만 바꾸는 경우 → 누구든 가능
+      allow update: if isSignedIn() &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likesCount']);
+
       allow create: if isSignedIn();
-    }
+
+      // 하위 컬렉션 'likes' 권한 설정 추가
+    match /likes/{userId} {
+      allow read, write: if isSignedIn(); // 또는 필요 시 write만 허용
+  }
+}
 
     match /users/{userId} {
       allow read: if isSignedIn() && (isOwner(userId) || isAdmin());
@@ -77,8 +89,7 @@ service cloud.firestore {
 
     match /recommended_places/{docId} {
       allow read: if true;
-      allow write: if isSignedIn() && isAdmin();
-      allow create: if isSignedIn() && isAdmin();
+      allow write, create: if isSignedIn() && isAdmin();
     }
 
     // 나머지 모든 문서는 차단

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^2.6.1",
         "@tanstack/react-query": "^5.36.0",
         "@tanstack/react-query-devtools": "^5.72.0",
+        "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "firebase": "^11.6.0",
         "lucide-react": "^0.503.0",
@@ -18,10 +19,12 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-firebase-hooks": "^5.1.1",
+        "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.0",
         "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.2.0",
         "vite": "^5.4.17"
       },
       "devDependencies": {
@@ -2724,6 +2727,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5445,6 +5457,15 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6057,6 +6078,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
+      "integrity": "sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "@tanstack/react-query": "^5.36.0",
     "@tanstack/react-query-devtools": "^5.72.0",
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.6.0",
     "lucide-react": "^0.503.0",
@@ -20,10 +21,12 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-firebase-hooks": "^5.1.1",
+    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.0",
     "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.2.0",
     "vite": "^5.4.17"
   },
   "devDependencies": {

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -9,7 +9,7 @@ import FormSubmitButton from "components/common/FormSubmitButton";
 
 import { useAddItinerary } from "services/queries/itinerary/useAddItinerary";
 
-import { updateItinerary } from "services/firestore";
+import { updateItinerary } from "services/itineraryService";
 
 export default function ItineraryForm({ initialData, isEditMode = false }) {
   const [title, setTitle] = useState(initialData?.title || "");

--- a/src/components/review/LikeButton.jsx
+++ b/src/components/review/LikeButton.jsx
@@ -5,8 +5,9 @@ import {
   useToggleReviewLike,
 } from "services/queries/review/useReviewLike";
 import { cn } from "utils/utils";
+import { useReviewDetail } from "services/queries/review/useReviewDetail";
 
-export default function LikeButton({ reviewId, likesCount }) {
+export default function LikeButton({ reviewId }) {
   const { user } = useUser();
   const userId = user?.uid;
 
@@ -18,10 +19,11 @@ export default function LikeButton({ reviewId, likesCount }) {
     reviewId,
     userId
   );
+  const { data: review } = useReviewDetail(reviewId);
 
   const handleLikeBtnClick = (e) => {
     e.stopPropagation();
-    if (!user || isChecking || isMutating) return;
+    if (!user || isMutating) return;
     mutate();
   };
 
@@ -31,11 +33,11 @@ export default function LikeButton({ reviewId, likesCount }) {
       disabled={!user || isMutating}
       className={cn(
         "flex items-center gap-1 transition-all",
-        isMutating ? "opacity-50 cursor-not-allowed" : ""
+        isMutating && "opacity-50 cursor-not-allowed"
       )}
       aria-label={hasLiked ? "좋아요 취소" : "좋아요 누르기"}
     >
-      {hasLiked === true ? (
+      {hasLiked ? (
         <AiFillHeart className="text-red-500" size={18} />
       ) : (
         <AiOutlineHeart
@@ -43,9 +45,7 @@ export default function LikeButton({ reviewId, likesCount }) {
           size={18}
         />
       )}
-      {typeof likesCount === "number" && (
-        <span className="text-sm text-gray-600">{likesCount}</span>
-      )}
+      <span className="text-sm text-gray-600">{review?.likesCount ?? 0}</span>
     </button>
   );
 }

--- a/src/components/review/LikeButton.jsx
+++ b/src/components/review/LikeButton.jsx
@@ -1,0 +1,51 @@
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
+import { useUser } from "hooks/useUser";
+import {
+  useReviewLikeStatus,
+  useToggleReviewLike,
+} from "services/queries/review/useReviewLike";
+import { cn } from "utils/utils";
+
+export default function LikeButton({ reviewId, likesCount }) {
+  const { user } = useUser();
+  const userId = user?.uid;
+
+  const { data: hasLiked, isLoading: isChecking } = useReviewLikeStatus(
+    reviewId,
+    userId
+  );
+  const { mutate, isPending: isMutating } = useToggleReviewLike(
+    reviewId,
+    userId
+  );
+
+  const handleLikeBtnClick = (e) => {
+    e.stopPropagation();
+    if (!user || isChecking || isMutating) return;
+    mutate();
+  };
+
+  return (
+    <button
+      onClick={handleLikeBtnClick}
+      disabled={!user || isChecking || isMutating}
+      className={cn(
+        "flex items-center gap-1 transition-all",
+        isChecking || isMutating ? "opacity-50 cursor-not-allowed" : ""
+      )}
+      aria-label={hasLiked ? "좋아요 취소" : "좋아요 누르기"}
+    >
+      {hasLiked ? (
+        <AiFillHeart className="text-red-500" size={18} />
+      ) : (
+        <AiOutlineHeart
+          className="text-gray-400 hover:text-red-500"
+          size={18}
+        />
+      )}
+      {typeof likesCount === "number" && (
+        <span className="text-sm text-gray-600">{likesCount}</span>
+      )}
+    </button>
+  );
+}

--- a/src/components/review/LikeButton.jsx
+++ b/src/components/review/LikeButton.jsx
@@ -28,14 +28,14 @@ export default function LikeButton({ reviewId, likesCount }) {
   return (
     <button
       onClick={handleLikeBtnClick}
-      disabled={!user || isChecking || isMutating}
+      disabled={!user || isMutating}
       className={cn(
         "flex items-center gap-1 transition-all",
-        isChecking || isMutating ? "opacity-50 cursor-not-allowed" : ""
+        isMutating ? "opacity-50 cursor-not-allowed" : ""
       )}
       aria-label={hasLiked ? "좋아요 취소" : "좋아요 누르기"}
     >
-      {hasLiked ? (
+      {hasLiked === true ? (
         <AiFillHeart className="text-red-500" size={18} />
       ) : (
         <AiOutlineHeart

--- a/src/components/review/ReviewCard.jsx
+++ b/src/components/review/ReviewCard.jsx
@@ -73,7 +73,6 @@ export default function ReviewCard({ review }) {
           <span>{authorName || "익명"}</span>
           <div className="flex items-center gap-2">
             <LikeButton reviewId={id} />
-            <span>{review.likesCount ?? 0}</span>
           </div>
         </div>
       </div>

--- a/src/components/review/ReviewCard.jsx
+++ b/src/components/review/ReviewCard.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import LikeButton from "./LikeButton";
 
 /**
  * 리뷰 정보를 카드 형태로 표시하는 컴포넌트
@@ -67,12 +68,13 @@ export default function ReviewCard({ review }) {
             </span>
           ))}
         </div>
-        <p className="text-sm text-gray-700 mb-3 line-clamp-3">
-          {truncatedContent}
-        </p>
-        <div className="flex justify-between text-xs text-gray-400">
+        {/* 하단 정보 + 좋아요 버튼 */}
+        <div className="flex justify-between items-center text-xs text-gray-400">
           <span>{authorName || "익명"}</span>
-          <span>{formattedDate}</span>
+          <div className="flex items-center gap-2">
+            <LikeButton reviewId={id} />
+            <span>{review.likesCount ?? 0}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+import { observeAuth } from "services/auth";
+
+export const useUser = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = observeAuth((firebaseUser) => {
+      setUser(firebaseUser);
+    });
+
+    return () => unsubscribe(); // cleanup
+  }, []);
+
+  return { user };
+};

--- a/src/pages/review/Detail.jsx
+++ b/src/pages/review/Detail.jsx
@@ -4,6 +4,7 @@ import LoadingSpinner from "components/common/LoadingSpinner";
 import NotFoundMessage from "components/common/NotFoundMessage";
 import ReportButton from "components/Review/ReportButton";
 import { formatDate } from "utils/formatDate";
+import LikeButton from "components/review/LikeButton";
 
 export default function ReviewDetailPage() {
   const { id } = useParams();
@@ -23,6 +24,7 @@ export default function ReviewDetailPage() {
     authorName,
     createdAt,
     imageUrl,
+    likesCount,
   } = data;
 
   return (
@@ -68,7 +70,8 @@ export default function ReviewDetailPage() {
         {content || "리뷰 내용이 없습니다."}
       </div>
 
-      <div className="flex justify-end">
+      <div className="flex justify-end items-center gap-4 mt-8">
+        <LikeButton reviewId={id} likesCount={likesCount} />
         <ReportButton reviewId={id} />
       </div>
     </article>

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -7,8 +7,7 @@ import {
   onAuthStateChanged,
   updateProfile,
 } from "firebase/auth";
-import { auth } from "./firebase";
-import { db } from "./firestore";
+import { auth, db } from "./firebase";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 
 // 회원가입

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -129,5 +129,3 @@ export const deleteItinerary = async (id) => {
     throw error;
   }
 };
-
-export { db };

--- a/src/services/queries/itinerary/useAddItinerary.js
+++ b/src/services/queries/itinerary/useAddItinerary.js
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 
-import { createItinerary } from "services/firestore";
+import { createItinerary } from "services/itineraryService";
 import { updateDoc, doc, increment } from "firebase/firestore";
 import { db } from "services/firebase";
 import { auth } from "services/firebase";

--- a/src/services/queries/itinerary/useDeleteItinerary.js
+++ b/src/services/queries/itinerary/useDeleteItinerary.js
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { deleteItinerary } from "services/firestore";
+import { deleteItinerary } from "services/itineraryService";
 import { useMutation } from "@tanstack/react-query";
 
 import { updateDoc, doc, increment } from "firebase/firestore";

--- a/src/services/queries/itinerary/useItineraryDetail.js
+++ b/src/services/queries/itinerary/useItineraryDetail.js
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchItineraryById } from "../../firestore";
+import { fetchItineraryById } from "services/itineraryService";
 
 export const useItineraryDetail = (id) => {
   return useQuery({

--- a/src/services/queries/itinerary/useMyItineraries.js
+++ b/src/services/queries/itinerary/useMyItineraries.js
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchUserItineraries } from "../../firestore";
-import { auth } from "../../firebase";
+import { fetchUserItineraries } from "services/itineraryService";
+import { auth } from "services/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 
 export const useMyItineraries = (options = {}) => {

--- a/src/services/queries/review/useAddReview.js
+++ b/src/services/queries/review/useAddReview.js
@@ -79,6 +79,7 @@ export default function useAddReview({
         authorId: user?.uid || "",
         authorName: user?.displayName || "익명",
         createdAt: serverTimestamp(),
+        likesCount: 0,
       });
 
       await updateDoc(doc(db, "users", user.uid), {

--- a/src/services/queries/review/useReviewDetail.js
+++ b/src/services/queries/review/useReviewDetail.js
@@ -9,7 +9,7 @@ import { db } from "../../firebase";
  */
 export const useReviewDetail = (id) => {
   return useQuery({
-    queryKey: ["review", id],
+    queryKey: ["review-detail", id],
     queryFn: async () => {
       try {
         const docRef = doc(db, "reviews", id);

--- a/src/services/queries/review/useReviewLike.js
+++ b/src/services/queries/review/useReviewLike.js
@@ -1,5 +1,3 @@
-// queries/review/useReviewLike.js
-
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   likeReview,
@@ -16,14 +14,17 @@ export const useReviewLikeStatus = (reviewId, userId) =>
 
 export const useToggleReviewLike = (reviewId, userId) => {
   const queryClient = useQueryClient();
-  const { data: hasLiked } = useReviewLikeStatus(reviewId, userId);
-
-  const mutationFn = hasLiked ? unlikeReview : likeReview;
 
   return useMutation({
-    mutationFn: () => mutationFn(reviewId, userId),
+    mutationFn: async () => {
+      const hasLiked = await hasUserLikedReview(reviewId, userId);
+      return hasLiked
+        ? unlikeReview(reviewId, userId)
+        : likeReview(reviewId, userId);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries(["review-like-status", reviewId, userId]);
+      // queryClient.invalidateQueries(["review-list"]); // 좋아요 수 포함 리스트라면 함께 무효화
     },
   });
 };

--- a/src/services/queries/review/useReviewLike.js
+++ b/src/services/queries/review/useReviewLike.js
@@ -30,8 +30,6 @@ export const useToggleReviewLike = (reviewId, userId) => {
         userId,
       ]);
 
-      // 좋아요 수가 반영 안 될 경우 강제 무효화
-      queryClient.removeQueries(["review-detail", reviewId]);
       queryClient.invalidateQueries(["review-detail", reviewId]);
     },
   });

--- a/src/services/queries/review/useReviewLike.js
+++ b/src/services/queries/review/useReviewLike.js
@@ -1,0 +1,29 @@
+// queries/review/useReviewLike.js
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  likeReview,
+  unlikeReview,
+  hasUserLikedReview,
+} from "services/reviewLikeService";
+
+export const useReviewLikeStatus = (reviewId, userId) =>
+  useQuery({
+    queryKey: ["review-like-status", reviewId, userId],
+    queryFn: () => hasUserLikedReview(reviewId, userId),
+    enabled: !!reviewId && !!userId,
+  });
+
+export const useToggleReviewLike = (reviewId, userId) => {
+  const queryClient = useQueryClient();
+  const { data: hasLiked } = useReviewLikeStatus(reviewId, userId);
+
+  const mutationFn = hasLiked ? unlikeReview : likeReview;
+
+  return useMutation({
+    mutationFn: () => mutationFn(reviewId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["review-like-status", reviewId, userId]);
+    },
+  });
+};

--- a/src/services/queries/review/useReviewLike.js
+++ b/src/services/queries/review/useReviewLike.js
@@ -22,9 +22,17 @@ export const useToggleReviewLike = (reviewId, userId) => {
         ? unlikeReview(reviewId, userId)
         : likeReview(reviewId, userId);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries(["review-like-status", reviewId, userId]);
-      // queryClient.invalidateQueries(["review-list"]); // 좋아요 수 포함 리스트라면 함께 무효화
+    onSuccess: async () => {
+      // 좋아요 상태 캐시 무효화
+      await queryClient.invalidateQueries([
+        "review-like-status",
+        reviewId,
+        userId,
+      ]);
+
+      // 좋아요 수가 반영 안 될 경우 강제 무효화
+      queryClient.removeQueries(["review-detail", reviewId]);
+      queryClient.invalidateQueries(["review-detail", reviewId]);
     },
   });
 };

--- a/src/services/reviewLikeService.js
+++ b/src/services/reviewLikeService.js
@@ -10,9 +10,11 @@ import {
 } from "firebase/firestore";
 
 export const likeReview = async (reviewId, userId) => {
-  await setDoc(doc(db, "reviews", reviewId, "likes", userId), {
-    likedAt: serverTimestamp(),
-  });
+  await setDoc(
+    doc(db, "reviews", reviewId, "likes", userId),
+    { likedAt: serverTimestamp() },
+    { merge: true } // 중복 방지
+  );
   await updateDoc(doc(db, "reviews", reviewId), {
     likesCount: increment(1),
   });

--- a/src/services/reviewLikeService.js
+++ b/src/services/reviewLikeService.js
@@ -1,0 +1,32 @@
+import { db } from "./firebase";
+import {
+  doc,
+  setDoc,
+  deleteDoc,
+  getDoc,
+  updateDoc,
+  increment,
+  serverTimestamp,
+} from "firebase/firestore";
+
+export const likeReview = async (reviewId, userId) => {
+  await setDoc(doc(db, "reviews", reviewId, "likes", userId), {
+    likedAt: serverTimestamp(),
+  });
+  await updateDoc(doc(db, "reviews", reviewId), {
+    likesCount: increment(1),
+  });
+};
+
+export const unlikeReview = async (reviewId, userId) => {
+  await deleteDoc(doc(db, "reviews", reviewId, "likes", userId));
+  await updateDoc(doc(db, "reviews", reviewId), {
+    likesCount: increment(-1),
+  });
+};
+
+export const hasUserLikedReview = async (reviewId, userId) => {
+  const ref = doc(db, "reviews", reviewId, "likes", userId);
+  const snap = await getDoc(ref);
+  return snap.exists();
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(...inputs));
+}


### PR DESCRIPTION
#### 주요 변경 사항
- reviewLikeService.js: Firestore 기반 좋아요/취소 기능 구현 (likes 서브컬렉션 활용)
- useReviewLike.js: React Query로 좋아요 상태 조회 및 토글 훅 분리
- LikeButton.jsx: 좋아요 UI 컴포넌트 구현 (하트 아이콘 + 좋아요 수 포함)
- AiOutlineHeart, AiFillHeart 기반 실시간 UI 전환
- mutate 실행 시 review-like-status, review-detail 캐시 무효화 처리
- 좋아요 수가 review.likesCount에 실시간 반영되도록 상세/목록 페이지 연동
- Firebase Rules에 likesCount 필드만 업데이트 허용 조건 추가
- LikeButton 내 user, isMutating 상태에 따른 비활성화 및 클릭 방지 처리
- 버튼 클릭 시 콘솔 로그 제거 및 UX 개선 (깜빡임 없이 자연스럽게 업데이트)

#### 고려 및 해결된 이슈
- Firestore 보안 규칙 누락으로 likesCount 업데이트 실패 → rules 수정 및 배포
- 서브컬렉션(likes) 쓰기 권한 문제 해결 → reviews/{reviewId}/likes/{userId}에 대해 별도 match 추가
- 좋아요 토글 시 review 데이터 자동 refetch 안 됨 → invalidateQueries(["review-detail", id]) 추가
- 좋아요 버튼 클릭 시 반응 지연 → isLoading → isMutating 기준으로 조건 수정
- 좋아요 수 중복 렌더링 방지 → LikeButton 내부 수치 표시로 일원화
- UI 깜빡임 → 자연스러운 전환 처리를 위해 invalidate 타이밍 조절
