### PR TITLE
feat: 리뷰 상세 페이지 댓글 기능 전체 구현 (CRUD + Optimistic UI)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,14 @@ service cloud.firestore {
 
       allow create: if isSignedIn();
 
+    // 댓글 권한 추가
+    match /comments/{commentId} {
+      allow read: if true;
+      allow create: if isSignedIn();
+      allow delete: if isSignedIn() && isOwner(resource.data.authorId);
+    }
+
+
       // 하위 컬렉션 'likes' 권한 설정 추가
     match /likes/{userId} {
       allow read, write: if isSignedIn(); // 또는 필요 시 write만 허용

--- a/src/components/review/CommentItem.jsx
+++ b/src/components/review/CommentItem.jsx
@@ -13,7 +13,11 @@ export default function CommentItem({ comment, currentUserId }) {
     <div className="border p-4 rounded">
       <div className="text-sm text-gray-600 mb-1">
         <span className="font-semibold">{authorName}</span> ·{" "}
-        <span>{new Date(createdAt).toLocaleString()}</span>
+        <span>
+          {createdAt?.toDate?.()
+            ? new Date(createdAt.toDate()).toLocaleString()
+            : "날짜 없음"}
+        </span>
       </div>
       <p className="text-gray-800">{content}</p>
       {isAuthor && (

--- a/src/components/review/CommentItem.jsx
+++ b/src/components/review/CommentItem.jsx
@@ -1,12 +1,13 @@
-// components/review/CommentItem.jsx
-export default function CommentItem({ comment, currentUserId }) {
+import { useDeleteComment } from "services/queries/review/useDeleteComment";
+
+export default function CommentItem({ comment, currentUserId, reviewId }) {
   const { id, content, createdAt, authorId, authorName } = comment;
-
   const isAuthor = currentUserId === authorId;
+  const { mutate, isPending } = useDeleteComment(reviewId);
 
-  const handleDelete = () => {
+  const handleCommentDelete = () => {
     if (!confirm("댓글을 삭제하시겠습니까?")) return;
-    // TODO: 댓글 삭제 mutation 연결
+    mutate(id);
   };
 
   return (
@@ -22,10 +23,11 @@ export default function CommentItem({ comment, currentUserId }) {
       <p className="text-gray-800">{content}</p>
       {isAuthor && (
         <button
-          onClick={handleDelete}
+          onClick={handleCommentDelete}
+          disabled={isPending}
           className="text-sm text-red-500 mt-2 hover:underline"
         >
-          삭제
+          {isPending ? "삭제 중..." : "삭제"}
         </button>
       )}
     </div>

--- a/src/components/review/CommentItem.jsx
+++ b/src/components/review/CommentItem.jsx
@@ -1,0 +1,29 @@
+// components/review/CommentItem.jsx
+export default function CommentItem({ comment, currentUserId }) {
+  const { id, content, createdAt, authorId, authorName } = comment;
+
+  const isAuthor = currentUserId === authorId;
+
+  const handleDelete = () => {
+    if (!confirm("댓글을 삭제하시겠습니까?")) return;
+    // TODO: 댓글 삭제 mutation 연결
+  };
+
+  return (
+    <div className="border p-4 rounded">
+      <div className="text-sm text-gray-600 mb-1">
+        <span className="font-semibold">{authorName}</span> ·{" "}
+        <span>{new Date(createdAt).toLocaleString()}</span>
+      </div>
+      <p className="text-gray-800">{content}</p>
+      {isAuthor && (
+        <button
+          onClick={handleDelete}
+          className="text-sm text-red-500 mt-2 hover:underline"
+        >
+          삭제
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -1,28 +1,13 @@
 // components/review/CommentList.jsx
 import { useState } from "react";
-import CommentItem from "./CommentItem";
+import { useComments } from "services/queries/review/useComments";
+import CommentItem from "components/review/CommentItem";
 
-const mockComments = [
-  {
-    id: "c1",
-    content: "정말 좋은 정보 감사합니다!",
-    createdAt: new Date().toISOString(),
-    authorId: "u1",
-    authorName: "유지니",
-  },
-  {
-    id: "c2",
-    content: "덕분에 많은 도움이 됐어요.",
-    createdAt: new Date().toISOString(),
-    authorId: "u2",
-    authorName: "하람",
-  },
-];
-
-export default function CommentList({ currentUserId }) {
+export default function CommentList({ currentUserId, reviewId }) {
   const [content, setContent] = useState("");
+  const { data: comments, isLoading } = useComments(reviewId);
 
-  const handleSubmit = (e) => {
+  const handleCommentSubmit = (e) => {
     e.preventDefault();
     if (!content.trim()) return;
     // TODO: 댓글 등록 mutation 연결
@@ -31,7 +16,7 @@ export default function CommentList({ currentUserId }) {
 
   return (
     <div className="mt-8 space-y-4">
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <form onSubmit={handleCommentSubmit} className="flex flex-col gap-2">
         <textarea
           className="border p-2 rounded resize-none"
           rows={3}
@@ -47,14 +32,21 @@ export default function CommentList({ currentUserId }) {
         </button>
       </form>
 
+      {/* 댓글 목록 */}
       <div className="space-y-4">
-        {mockComments.map((comment) => (
-          <CommentItem
-            key={comment.id}
-            comment={comment}
-            currentUserId={currentUserId}
-          />
-        ))}
+        {isLoading ? (
+          <p className="text-gray-500 text-sm">댓글을 불러오는 중...</p>
+        ) : comments?.length > 0 ? (
+          comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              currentUserId={currentUserId}
+            />
+          ))
+        ) : (
+          <p className="text-gray-400 text-sm">첫 댓글을 남겨보세요.</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -56,6 +56,7 @@ export default function CommentList({ currentUserId, reviewId }) {
               key={comment.id}
               comment={comment}
               currentUserId={currentUserId}
+              reviewId={reviewId}
             />
           ))
         ) : (

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -1,0 +1,61 @@
+// components/review/CommentList.jsx
+import { useState } from "react";
+import CommentItem from "./CommentItem";
+
+const mockComments = [
+  {
+    id: "c1",
+    content: "정말 좋은 정보 감사합니다!",
+    createdAt: new Date().toISOString(),
+    authorId: "u1",
+    authorName: "유지니",
+  },
+  {
+    id: "c2",
+    content: "덕분에 많은 도움이 됐어요.",
+    createdAt: new Date().toISOString(),
+    authorId: "u2",
+    authorName: "하람",
+  },
+];
+
+export default function CommentList({ currentUserId }) {
+  const [content, setContent] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!content.trim()) return;
+    // TODO: 댓글 등록 mutation 연결
+    setContent("");
+  };
+
+  return (
+    <div className="mt-8 space-y-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <textarea
+          className="border p-2 rounded resize-none"
+          rows={3}
+          placeholder="댓글을 입력하세요"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="self-end bg-black text-white px-4 py-2 rounded"
+        >
+          댓글 작성
+        </button>
+      </form>
+
+      <div className="space-y-4">
+        {mockComments.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            currentUserId={currentUserId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -2,20 +2,32 @@
 import { useState } from "react";
 import { useComments } from "services/queries/review/useComments";
 import CommentItem from "components/review/CommentItem";
+import { useUser } from "hooks/useUser";
+import { useAddComment } from "services/queries/review/useAddComment";
 
 export default function CommentList({ currentUserId, reviewId }) {
   const [content, setContent] = useState("");
+  const { user } = useUser();
   const { data: comments, isLoading } = useComments(reviewId);
+
+  const { mutate, isPending } = useAddComment(reviewId);
 
   const handleCommentSubmit = (e) => {
     e.preventDefault();
-    if (!content.trim()) return;
-    // TODO: 댓글 등록 mutation 연결
+    if (!user || !content.trim()) return;
+
+    mutate({
+      content,
+      authorId: user.uid,
+      authorName: user.displayName || "익명",
+    });
+
     setContent("");
   };
 
   return (
     <div className="mt-8 space-y-4">
+      {/* 댓글 작성 폼 */}
       <form onSubmit={handleCommentSubmit} className="flex flex-col gap-2">
         <textarea
           className="border p-2 rounded resize-none"
@@ -23,12 +35,14 @@ export default function CommentList({ currentUserId, reviewId }) {
           placeholder="댓글을 입력하세요"
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          disabled={isPending}
         />
         <button
           type="submit"
-          className="self-end bg-black text-white px-4 py-2 rounded"
+          disabled={isPending || !content.trim()}
+          className="self-end bg-black text-white px-4 py-2 rounded disabled:opacity-50"
         >
-          댓글 작성
+          {isPending ? "작성 중..." : "댓글 작성"}
         </button>
       </form>
 

--- a/src/pages/review/Detail.jsx
+++ b/src/pages/review/Detail.jsx
@@ -3,11 +3,16 @@ import { useReviewDetail } from "services/queries/review/useReviewDetail";
 import LoadingSpinner from "components/common/LoadingSpinner";
 import NotFoundMessage from "components/common/NotFoundMessage";
 import ReportButton from "components/Review/ReportButton";
+
 import { formatDate } from "utils/formatDate";
+import { useUser } from "hooks/useUser";
+
 import LikeButton from "components/review/LikeButton";
+import CommentList from "components/review/CommentList";
 
 export default function ReviewDetailPage() {
   const { id } = useParams();
+  const { user } = useUser();
   const { data, isLoading, isError } = useReviewDetail(id);
 
   const navigate = useNavigate();
@@ -74,6 +79,12 @@ export default function ReviewDetailPage() {
         <LikeButton reviewId={id} likesCount={likesCount} />
         <ReportButton reviewId={id} />
       </div>
+
+      {/* 🔽 댓글 섹션 추가 */}
+      <section className="mt-10">
+        <h2 className="text-xl font-semibold mb-4">댓글</h2>
+        <CommentList currentUserId={user?.uid} />
+      </section>
     </article>
   );
 }

--- a/src/pages/review/Detail.jsx
+++ b/src/pages/review/Detail.jsx
@@ -80,10 +80,10 @@ export default function ReviewDetailPage() {
         <ReportButton reviewId={id} />
       </div>
 
-      {/* 🔽 댓글 섹션 추가 */}
+      {/* 댓글 섹션 */}
       <section className="mt-10">
         <h2 className="text-xl font-semibold mb-4">댓글</h2>
-        <CommentList currentUserId={user?.uid} />
+        <CommentList currentUserId={user?.uid} reviewId={id} />
       </section>
     </article>
   );

--- a/src/services/queries/review/useAddComment.js
+++ b/src/services/queries/review/useAddComment.js
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { collection, serverTimestamp, addDoc } from "firebase/firestore";
+import { db } from "services/firebase";
+
+export const useAddComment = (reviewId) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ content, authorId, authorName }) => {
+      const commentRef = collection(db, "reviews", reviewId, "comments");
+      await addDoc(commentRef, {
+        content,
+        authorId,
+        authorName,
+        createdAt: serverTimestamp(),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["comments", reviewId]);
+    },
+  });
+};

--- a/src/services/queries/review/useComments.js
+++ b/src/services/queries/review/useComments.js
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { db } from "services/firebase";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
+
+export const useComments = (reviewId) => {
+  return useQuery({
+    queryKey: ["comments", reviewId],
+    queryFn: async () => {
+      const commentsRef = collection(db, "reviews", reviewId, "comments");
+      const q = query(commentsRef, orderBy("createdAt", "asc"));
+      const querySnapshot = await getDocs(q);
+
+      return querySnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+    },
+    enabled: !!reviewId,
+  });
+};

--- a/src/services/queries/review/useDeleteComment.js
+++ b/src/services/queries/review/useDeleteComment.js
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { doc, deleteDoc } from "firebase/firestore";
+import { db } from "services/firebase";
+
+export const useDeleteComment = (reviewId) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (commentId) => {
+      const commentDoc = doc(db, "reviews", reviewId, "comments", commentId);
+      await deleteDoc(commentDoc);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["comments", reviewId]);
+    },
+  });
+};

--- a/src/services/queries/review/useDeleteComment.js
+++ b/src/services/queries/review/useDeleteComment.js
@@ -10,7 +10,28 @@ export const useDeleteComment = (reviewId) => {
       const commentDoc = doc(db, "reviews", reviewId, "comments", commentId);
       await deleteDoc(commentDoc);
     },
-    onSuccess: () => {
+    // Optimistic Update
+    onMutate: async (commentId) => {
+      await queryClient.cancelQueries({ queryKey: ["comments", reviewId] });
+
+      const prevComments = queryClient.getQueryData(["comments", reviewId]);
+
+      queryClient.setQueryData(["comments", reviewId], (old) =>
+        old?.filter((comment) => comment.id !== commentId)
+      );
+
+      return { prevComments };
+    },
+
+    // 실패 시 롤백
+    onError: (err, commentId, context) => {
+      if (context?.prevComments) {
+        queryClient.setQueryData(["comments", reviewId], context.prevComments);
+      }
+    },
+
+    // 성공 시 re-fetch로 동기화
+    onSettled: () => {
       queryClient.invalidateQueries(["comments", reviewId]);
     },
   });

--- a/src/services/queries/review/useRecentReviews.js
+++ b/src/services/queries/review/useRecentReviews.js
@@ -7,7 +7,7 @@ import {
   limit,
   getDocs,
 } from "firebase/firestore";
-import { app } from "../../firebase"; // 기존 firebase.js 경로에 따라 조정
+import { app } from "services/firebase";
 
 const db = getFirestore(app);
 


### PR DESCRIPTION
## 주요 작업 내용

### 댓글 기능 전체 구현
- 리뷰 상세 페이지에 댓글 섹션 UI 추가
- 댓글 목록 조회: `useComments` 훅을 통해 Firestore 서브컬렉션에서 fetch
- 댓글 등록 기능: `useAddComment` 훅 + `React Query` mutation 적용
- 댓글 삭제 기능: `useDeleteComment` 훅 구현 (본인만 삭제 가능)
- 삭제 시 Optimistic UI 처리 → 즉시 UI 반영 + 실패 시 롤백 + 재동기화

### Firestore 보안 규칙 강화
- `reviews/{reviewId}/comments/{commentId}` 경로에 read / create / delete 권한 추가
- 인증된 사용자만 작성 가능, 작성자 본인만 삭제 가능

### 기타 수정
- Firestore `Timestamp` → `toDate()` 변환 적용 (`Invalid Date` 오류 해결)
- 삭제 로딩 처리 및 중복 클릭 방지 처리