### PR TITLE
feat: 프로필 수정 기능 구현 및 Firebase 유저 직렬화 오류 해결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { setUser, clearUser } from "store/userSlice";
 
 import { observeAuth } from "./services/auth";
+import { fetchUserWithProfile } from "services/userService";
 
 import Header from "components/layout/Header";
 import Footer from "components/layout/Footer";
@@ -28,8 +29,8 @@ import CreateChatRoomPage from "pages/Chat/Create";
 import ChatRoomListPage from "pages/Chat/List";
 import ChatRoomDetailPage from "pages/Chat/Detail";
 import MyPage from "pages/mypage/MyPage";
-import RecommendationListPage from "./pages/recommendations/List";
-import RecommendationDetailPage from "./pages/recommendations/Detail";
+import RecommendationListPage from "pages/recommendations/List";
+import RecommendationDetailPage from "pages/recommendations/Detail";
 
 function App() {
   const dispatch = useDispatch();
@@ -39,16 +40,9 @@ function App() {
   const isRecommendationPage = location.pathname.startsWith("/recommendations");
 
   useEffect(() => {
-    const unsubscribe = observeAuth((user) => {
+    const unsubscribe = observeAuth(async (user) => {
       if (user) {
-        dispatch(
-          setUser({
-            uid: user.uid,
-            email: user.email,
-            displayName: user.displayName,
-            photoURL: user.photoURL,
-          })
-        );
+        await fetchUserWithProfile(user, dispatch); // bio 포함하여 Redux 저장
       } else {
         dispatch(clearUser());
       }

--- a/src/components/modal/ProfileEditModal.jsx
+++ b/src/components/modal/ProfileEditModal.jsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useUpdateProfile } from "hooks/useUpdateProfile";
+
+export default function ProfileEditModal({ isOpen, onClose, user }) {
+  const [displayName, setDisplayName] = useState(user?.displayName || "");
+  const [bio, setBio] = useState(user?.bio || "");
+  const { updateProfile, isLoading } = useUpdateProfile();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateProfile({ displayName, bio });
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-xl font-semibold mb-4 text-black">프로필 수정</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              닉네임
+            </label>
+            <input
+              type="text"
+              className="w-full border px-3 py-2 rounded text-sm"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              소개 문구
+            </label>
+            <textarea
+              className="w-full border px-3 py-2 rounded resize-none text-sm"
+              rows={3}
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2 mt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-100"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="px-4 py-2 rounded bg-black text-white hover:bg-gray-900"
+            >
+              {isLoading ? "저장 중..." : "저장"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modal/ProfileEditModal.jsx
+++ b/src/components/modal/ProfileEditModal.jsx
@@ -25,7 +25,7 @@ export default function ProfileEditModal({ isOpen, onClose, user }) {
             </label>
             <input
               type="text"
-              className="w-full border px-3 py-2 rounded text-sm"
+              className="w-full border px-3 py-2 rounded text-sm text-black"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
             />
@@ -35,7 +35,7 @@ export default function ProfileEditModal({ isOpen, onClose, user }) {
               소개 문구
             </label>
             <textarea
-              className="w-full border px-3 py-2 rounded resize-none text-sm"
+              className="w-full border px-3 py-2 rounded resize-none text-sm text-black"
               rows={3}
               value={bio}
               onChange={(e) => setBio(e.target.value)}

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { logout } from "services/auth";
 import { clearUser } from "store/userSlice";
-import PropTypes from "prop-types";
 import ProfileEditModal from "components/modal/ProfileEditModal";
 
-export default function ProfileSection({ user = null }) {
+export default function ProfileSection() {
+  const user = useSelector((state) => state.user.user);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
@@ -78,11 +78,3 @@ export default function ProfileSection({ user = null }) {
     </>
   );
 }
-
-ProfileSection.propTypes = {
-  user: PropTypes.shape({
-    displayName: PropTypes.string,
-    email: PropTypes.string,
-    photoURL: PropTypes.string,
-  }),
-};

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -38,8 +38,10 @@ export default function ProfileSection() {
         <h1 className="text-2xl font-semibold">
           {user?.displayName || user?.email || "닉네임 없음"}
         </h1>
-        <p className="text-sm text-gray-300 mb-4">
-          {user?.isPremium ? "Premium Member" : "일반 회원"}
+
+        {/* 소개 문구 출력 */}
+        <p className="text-sm text-gray-300 my-4 whitespace-pre-line">
+          {user?.bio?.trim() ? user.bio : "소개 문구가 없습니다."}
         </p>
 
         {/* 버튼 그룹 */}

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -4,9 +4,11 @@ import { useNavigate } from "react-router-dom";
 import { logout } from "services/auth";
 import { clearUser } from "store/userSlice";
 import PropTypes from "prop-types";
+import ProfileEditModal from "components/modal/ProfileEditModal";
 
 export default function ProfileSection({ user = null }) {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -26,46 +28,54 @@ export default function ProfileSection({ user = null }) {
   };
 
   return (
-    <div className="bg-gradient-to-b from-[#1f2937] to-[#111827] py-12 text-center">
-      <img
-        src={user?.photoURL || "/default_profile.png"}
-        alt="프로필 이미지"
-        className="w-24 h-24 rounded-full mx-auto border-2 border-white mb-4"
-      />
-      <h1 className="text-2xl font-semibold">
-        {user?.displayName || user?.email || "닉네임 없음"}
-      </h1>
-      <p className="text-sm text-gray-300 mb-4">
-        {user?.isPremium ? "Premium Member" : "일반 회원"}
-      </p>
+    <>
+      <div className="bg-gradient-to-b from-[#1f2937] to-[#111827] py-12 text-center">
+        <img
+          src={user?.photoURL || "/default_profile.png"}
+          alt="프로필 이미지"
+          className="w-24 h-24 rounded-full mx-auto border-2 border-white mb-4"
+        />
+        <h1 className="text-2xl font-semibold">
+          {user?.displayName || user?.email || "닉네임 없음"}
+        </h1>
+        <p className="text-sm text-gray-300 mb-4">
+          {user?.isPremium ? "Premium Member" : "일반 회원"}
+        </p>
 
-      {/* 버튼 그룹 */}
-      <div className="flex justify-center gap-4 flex-wrap">
-        <button
-          onClick={() => alert("준비 중인 기능입니다.")}
-          className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition"
-        >
-          프로필 수정
-        </button>
-        <button
-          onClick={() => alert("준비 중인 기능입니다.")}
-          className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition"
-        >
-          설정
-        </button>
-        <button
-          onClick={handleLogout}
-          disabled={isLoggingOut}
-          className={`min-w-[100px] px-4 py-2 border border-white rounded transition ${
-            isLoggingOut
-              ? "bg-gray-500 text-white cursor-not-allowed"
-              : "text-red-500 hover:bg-red-500 hover:text-white"
-          }`}
-        >
-          {isLoggingOut ? "로그아웃 중..." : "로그아웃"}
-        </button>
+        {/* 버튼 그룹 */}
+        <div className="flex justify-center gap-4 flex-wrap">
+          <button
+            onClick={() => setIsEditModalOpen(true)}
+            className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition"
+          >
+            프로필 수정
+          </button>
+          <button
+            onClick={() => alert("준비 중인 기능입니다.")}
+            className="min-w-[100px] px-4 py-2 border border-white rounded hover:bg-white hover:text-black transition"
+          >
+            설정
+          </button>
+          <button
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            className={`min-w-[100px] px-4 py-2 border border-white rounded transition ${
+              isLoggingOut
+                ? "bg-gray-500 text-white cursor-not-allowed"
+                : "text-red-500 hover:bg-red-500 hover:text-white"
+            }`}
+          >
+            {isLoggingOut ? "로그아웃 중..." : "로그아웃"}
+          </button>
+        </div>
       </div>
-    </div>
+      {/* 모달 컴포넌트 렌더링 */}
+      <ProfileEditModal
+        isOpen={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
+        user={user}
+      />
+    </>
   );
 }
 

--- a/src/hooks/useUpdateProfile.js
+++ b/src/hooks/useUpdateProfile.js
@@ -1,10 +1,11 @@
 import { useState } from "react";
+import { useDispatch } from "react-redux";
+
 import { updateProfile as updateFirebaseProfile } from "firebase/auth";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 import { auth, db } from "services/firebase";
 import { useUser } from "hooks/useUser"; // 사용자 uid 얻기용 커스텀 훅
 import { setUser } from "store/userSlice";
-import { useDispatch } from "react-redux";
 
 export function useUpdateProfile() {
   const { user } = useUser(); // 현재 로그인 사용자
@@ -35,8 +36,10 @@ export function useUpdateProfile() {
       );
       dispatch(
         setUser({
-          ...user,
+          uid: user.uid,
+          email: user.email,
           displayName,
+          photoURL: user.photoURL || "",
           bio,
         })
       );

--- a/src/hooks/useUpdateProfile.js
+++ b/src/hooks/useUpdateProfile.js
@@ -3,9 +3,12 @@ import { updateProfile as updateFirebaseProfile } from "firebase/auth";
 import { doc, setDoc, serverTimestamp } from "firebase/firestore";
 import { auth, db } from "services/firebase";
 import { useUser } from "hooks/useUser"; // 사용자 uid 얻기용 커스텀 훅
+import { setUser } from "store/userSlice";
+import { useDispatch } from "react-redux";
 
 export function useUpdateProfile() {
   const { user } = useUser(); // 현재 로그인 사용자
+  const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -29,6 +32,13 @@ export function useUpdateProfile() {
           updatedAt: serverTimestamp(),
         },
         { merge: true }
+      );
+      dispatch(
+        setUser({
+          ...user,
+          displayName,
+          bio,
+        })
       );
     } catch (err) {
       console.error("프로필 업데이트 실패:", err);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,22 @@
+import { doc, getDoc } from "firebase/firestore";
+import { setUser } from "store/userSlice";
+import { db } from "services/firebase";
+
+export const fetchUserWithProfile = async (firebaseUser, dispatch) => {
+  if (!firebaseUser) return;
+
+  const userDocRef = doc(db, "users", firebaseUser.uid);
+  const userDoc = await getDoc(userDocRef);
+
+  const bio = userDoc.exists() ? userDoc.data().bio || "" : "";
+
+  dispatch(
+    setUser({
+      uid: firebaseUser.uid,
+      email: firebaseUser.email,
+      displayName: firebaseUser.displayName,
+      photoURL: firebaseUser.photoURL,
+      bio,
+    })
+  );
+};

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,6 +1,7 @@
 import { doc, getDoc } from "firebase/firestore";
 import { setUser } from "store/userSlice";
 import { db } from "services/firebase";
+import { extractSafeUser } from "utils/extractSafeUser";
 
 export const fetchUserWithProfile = async (firebaseUser, dispatch) => {
   if (!firebaseUser) return;
@@ -10,13 +11,6 @@ export const fetchUserWithProfile = async (firebaseUser, dispatch) => {
 
   const bio = userDoc.exists() ? userDoc.data().bio || "" : "";
 
-  dispatch(
-    setUser({
-      uid: firebaseUser.uid,
-      email: firebaseUser.email,
-      displayName: firebaseUser.displayName,
-      photoURL: firebaseUser.photoURL,
-      bio,
-    })
-  );
+  const safeUser = extractSafeUser(firebaseUser, bio);
+  dispatch(setUser(safeUser));
 };

--- a/src/utils/extractSafeUser.js
+++ b/src/utils/extractSafeUser.js
@@ -1,0 +1,7 @@
+export const extractSafeUser = (user, bio = "") => ({
+  uid: user.uid,
+  email: user.email,
+  displayName: user.displayName || "",
+  photoURL: user.photoURL || "",
+  bio,
+});


### PR DESCRIPTION
### 작업 개요
- 마이페이지 내 프로필 수정 모달 UI 구성 및 기능 연결
- Firebase 유저 정보 업데이트 시, Redux 상태까지 일관성 있게 반영
- Firebase User 객체의 직렬화 오류 경고 해결을 위한 유틸 함수 도입

### 상세 변경 내역

1. 프로필 수정 기능 구현
- ProfileEditModal 컴포넌트 생성: 닉네임, 소개 문구 수정 UI 구현
- useUpdateProfile 훅에서 Firebase Auth + Firestore 동시에 업데이트
- 저장 완료 시 모달 닫기 및 상태 반영

2. Redux 상태 누락 문제 수정
- 프로필 수정 후, dispatch(setUser(...)) 누락된 문제 해결
- 새 displayName, bio가 바로 반영되도록 Redux 상태 갱신

3. 로그인 시 bio 포함 상태 저장
- fetchUserWithProfile 함수 내에서 Firestore에서 bio 가져와 Redux에 함께 저장
- 기존 isPremium 필드 제거 (사용하지 않기로 결정)

4. Firebase User 직렬화 오류 해결
- extractSafeUser() 유틸 추가: Firebase 원본 객체에서 직렬화 가능한 필드만 추출
- fetchUserWithProfile()에서만 사용 → Redux 저장 시 직렬화 경고 제거

### 참고
- extractSafeUser()는 Firebase User 원본을 Redux에 저장할 때만 사용
- useUpdateProfile()에서는 안전한 Redux 상태 기반으로 수동 필드 갱신
- 추후 확장 시, photoURL이나 추가 사용자 필드에 동일한 방식 적용 가능
