### PR TITLE
feat: 일정 상세 페이지에 세부 일정 기능 및 체크리스트 UI/UX 개선

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,9 +19,10 @@ service cloud.firestore {
     }
 
     match /itineraries/{itineraryId} {
-      allow read: if isSignedIn(); // 로그인한 사람 누구나 읽기 가능
-      allow write: if isSignedIn() && isOwner(resource.data.userId);
+      allow read: if isSignedIn();
       allow create: if isSignedIn();
+      allow update: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
+      allow delete: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
     }
 
     match /reviews/{reviewId} {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "firebase": "^11.6.0",
+        "lodash": "^4.17.21",
         "lucide-react": "^0.503.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -3951,6 +3952,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "firebase": "^11.6.0",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.503.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/components/common/FloatingButtons.jsx
+++ b/src/components/common/FloatingButtons.jsx
@@ -1,0 +1,50 @@
+import { Pencil, Trash2 } from "lucide-react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useDeleteItinerary } from "services/queries/itinerary/useDeleteItinerary";
+
+export function EditFloatingButton() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <button
+      onClick={() => navigate(`/itinerary/edit/${id}`)}
+      className="bg-gray-900 text-white p-3 rounded-full shadow-lg hover:bg-gray-800 transition"
+      aria-label="일정 수정"
+    >
+      <Pencil className="w-4 h-4" />
+    </button>
+  );
+}
+
+export function DeleteFloatingButton() {
+  const { id } = useParams();
+  const { mutate, isPending } = useDeleteItinerary(); // 커스텀 훅 사용
+
+  const handleDelete = () => {
+    if (confirm("정말로 이 일정을 삭제하시겠습니까?")) {
+      mutate(id); // ID 전달
+    }
+  };
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={isPending}
+      className="bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-700 transition"
+      aria-label="일정 삭제"
+    >
+      <Trash2 className="w-4 h-4" />
+    </button>
+  );
+}
+
+// 두 버튼을 묶어주는 Wrapper
+export default function FloatingButtons() {
+  return (
+    <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">
+      <EditFloatingButton />
+      <DeleteFloatingButton />
+    </div>
+  );
+}

--- a/src/components/common/LayoutWrapper.jsx
+++ b/src/components/common/LayoutWrapper.jsx
@@ -1,0 +1,7 @@
+export default function LayoutWrapper({ children }) {
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      {children}
+    </div>
+  );
+}

--- a/src/components/itinerary/ChecklistSection.jsx
+++ b/src/components/itinerary/ChecklistSection.jsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import {
+  ClipboardCheck,
+  Plus,
+  ShieldCheck,
+  ShoppingBag,
+  Trash2,
+} from "lucide-react";
+
+export default function ChecklistSection({
+  checklist = { required: [], optional: [] },
+}) {
+  const [localChecklist, setLocalChecklist] = useState(checklist);
+  const [newItem, setNewItem] = useState({ type: "required", text: "" });
+
+  const handleAddItem = () => {
+    if (!newItem.text.trim()) return;
+
+    setLocalChecklist((prev) => ({
+      ...prev,
+      [newItem.type]: [
+        ...prev[newItem.type],
+        { text: newItem.text.trim(), checked: false },
+      ],
+    }));
+    setNewItem({ ...newItem, text: "" });
+  };
+
+  const toggleCheck = (type, index) => {
+    setLocalChecklist((prev) => {
+      const updated = [...prev[type]];
+      updated[index] = {
+        ...updated[index],
+        checked: !updated[index].checked,
+      };
+      return {
+        ...prev,
+        [type]: updated,
+      };
+    });
+  };
+
+  const handleDeleteItem = (type, index) => {
+    setLocalChecklist((prev) => ({
+      ...prev,
+      [type]: prev[type].filter((_, i) => i !== index),
+    }));
+  };
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl px-6 py-5 shadow-sm">
+      <h3 className="text-sm text-gray-500 font-semibold mb-4 flex items-center gap-2">
+        <ClipboardCheck className="w-4 h-4" />
+        여행 준비 체크리스트
+      </h3>
+
+      {/* 추가 입력 */}
+      <div className="flex gap-2 mb-4">
+        <select
+          className="border rounded px-2 py-1 text-sm"
+          value={newItem.type}
+          onChange={(e) =>
+            setNewItem((prev) => ({ ...prev, type: e.target.value }))
+          }
+        >
+          <option value="required">필수</option>
+          <option value="optional">선택</option>
+        </select>
+        <input
+          type="text"
+          className="border rounded px-2 py-1 text-sm flex-1"
+          placeholder="항목 추가"
+          value={newItem.text}
+          onChange={(e) =>
+            setNewItem((prev) => ({ ...prev, text: e.target.value }))
+          }
+          onKeyDown={(e) => e.key === "Enter" && handleAddItem()}
+        />
+        <button
+          onClick={handleAddItem}
+          className="bg-gray-800 text-white text-sm px-3 py-1 rounded"
+        >
+          <Plus className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* 필수 항목 */}
+      <div className="mb-4">
+        <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+          <ShieldCheck className="w-4 h-4 text-[#F87171]" />
+          필수 준비물
+        </h4>
+        <ul className="space-y-2 text-sm text-gray-800">
+          {localChecklist.required.map((item, idx) => (
+            <li key={`r-${idx}`} className="flex justify-between items-center">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={item.checked}
+                  onChange={() => toggleCheck("required", idx)}
+                  className="accent-[#6C8BA4]"
+                />
+                <span
+                  className={item.checked ? "line-through text-gray-400" : ""}
+                >
+                  {item.text}
+                </span>
+              </label>
+              <button
+                onClick={() => handleDeleteItem("required", idx)}
+                aria-label="삭제"
+              >
+                <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* 선택 항목 */}
+      <div>
+        <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+          <ShoppingBag className="w-4 h-4 text-[#6C8BA4]" />
+          선택 준비물
+        </h4>
+        <ul className="space-y-2 text-sm text-gray-800">
+          {localChecklist.optional.map((item, idx) => (
+            <li key={`r-${idx}`} className="flex justify-between items-center">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={item.checked}
+                  onChange={() => toggleCheck("optional", idx)}
+                  className="accent-[#6C8BA4]"
+                />
+                <span
+                  className={item.checked ? "line-through text-gray-400" : ""}
+                >
+                  {item.text}
+                </span>
+              </label>
+              <button
+                onClick={() => handleDeleteItem("optional", idx)}
+                aria-label="삭제"
+              >
+                <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/itinerary/ChecklistSection.jsx
+++ b/src/components/itinerary/ChecklistSection.jsx
@@ -125,69 +125,78 @@ export default function ChecklistSection({
       </div>
 
       {/* 필수 항목 */}
-      <div className="mb-4">
-        <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
-          <ShieldCheck className="w-4 h-4 text-[#F87171]" />
-          필수 준비물
-        </h4>
-        <ul className="space-y-2 text-sm text-gray-800">
-          {localChecklist.required.map((item, idx) => (
-            <li key={`r-${idx}`} className="flex justify-between items-center">
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={item.checked}
-                  onChange={() => toggleCheck("required", idx)}
-                  className="accent-[#6C8BA4]"
-                />
-                <span
-                  className={item.checked ? "line-through text-gray-400" : ""}
-                >
-                  {item.text}
-                </span>
-              </label>
-              <button
-                onClick={() => handleDeleteItem("required", idx)}
-                aria-label="삭제"
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* 필수 항목 */}
+        <div className="border rounded-xl p-4">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+            <ShieldCheck className="w-4 h-4 text-[#F87171]" />
+            필수 준비물
+          </h4>
+          <ul className="space-y-2 text-sm text-gray-800">
+            {localChecklist.required.map((item, idx) => (
+              <li
+                key={`r-${idx}`}
+                className="flex justify-between items-center"
               >
-                <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={item.checked}
+                    onChange={() => toggleCheck("required", idx)}
+                    className="accent-[#6C8BA4]"
+                  />
+                  <span
+                    className={item.checked ? "line-through text-gray-400" : ""}
+                  >
+                    {item.text}
+                  </span>
+                </label>
+                <button
+                  onClick={() => handleDeleteItem("required", idx)}
+                  aria-label="삭제"
+                >
+                  <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
 
-      {/* 선택 항목 */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
-          <ShoppingBag className="w-4 h-4 text-[#6C8BA4]" />
-          선택 준비물
-        </h4>
-        <ul className="space-y-2 text-sm text-gray-800">
-          {localChecklist.optional.map((item, idx) => (
-            <li key={`o-${idx}`} className="flex justify-between items-center">
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={item.checked}
-                  onChange={() => toggleCheck("optional", idx)}
-                  className="accent-[#6C8BA4]"
-                />
-                <span
-                  className={item.checked ? "line-through text-gray-400" : ""}
-                >
-                  {item.text}
-                </span>
-              </label>
-              <button
-                onClick={() => handleDeleteItem("optional", idx)}
-                aria-label="삭제"
+        {/* 선택 항목 */}
+        <div className="border rounded-xl p-4">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+            <ShoppingBag className="w-4 h-4 text-[#6C8BA4]" />
+            선택 준비물
+          </h4>
+          <ul className="space-y-2 text-sm text-gray-800">
+            {localChecklist.optional.map((item, idx) => (
+              <li
+                key={`o-${idx}`}
+                className="flex justify-between items-center"
               >
-                <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
-              </button>
-            </li>
-          ))}
-        </ul>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={item.checked}
+                    onChange={() => toggleCheck("optional", idx)}
+                    className="accent-[#6C8BA4]"
+                  />
+                  <span
+                    className={item.checked ? "line-through text-gray-400" : ""}
+                  >
+                    {item.text}
+                  </span>
+                </label>
+                <button
+                  onClick={() => handleDeleteItem("optional", idx)}
+                  aria-label="삭제"
+                >
+                  <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/src/components/itinerary/DayScheduleItem.jsx
+++ b/src/components/itinerary/DayScheduleItem.jsx
@@ -1,4 +1,4 @@
-import { Trash2 } from "lucide-react";
+import { Footprints, Trash2 } from "lucide-react";
 
 export default function DayScheduleItem({
   time,
@@ -8,17 +8,20 @@ export default function DayScheduleItem({
 }) {
   return (
     <li className="flex justify-between items-start space-x-4">
-      {/* 좌측: 시간 + 내용 */}
-      <div className="flex gap-4">
-        <div className="min-w-[60px] text-sm text-gray-500 font-semibold">
-          {time || "--:--"}
-        </div>
-        <div>
-          <p className="text-sm font-medium text-gray-900">{activity}</p>
-          {description && (
-            <p className="text-sm text-gray-500 mt-1">{description}</p>
-          )}
-        </div>
+      {/* 좌측: 시간 */}
+      <div className="min-w-[60px] text-sm text-gray-500 font-semibold">
+        {time || "--:--"}
+      </div>
+
+      {/* 가운데: 활동 + 설명 */}
+      <div className="flex-1">
+        <p className="flex items-center gap-2 text-sm font-medium text-gray-900">
+          <Footprints className="w-4 h-4 text-black" />
+          {activity}
+        </p>
+        {description && (
+          <p className="text-sm text-gray-500 mt-1">{description}</p>
+        )}
       </div>
 
       {/* 우측: 삭제 버튼 */}

--- a/src/components/itinerary/DayScheduleItem.jsx
+++ b/src/components/itinerary/DayScheduleItem.jsx
@@ -1,15 +1,36 @@
-export default function DayScheduleItem({ time, activity, description }) {
+import { Trash2 } from "lucide-react";
+
+export default function DayScheduleItem({
+  time,
+  activity,
+  description,
+  onDelete,
+}) {
   return (
-    <li className="flex items-start space-x-4">
-      <div className="min-w-[60px] text-sm text-gray-500 font-semibold">
-        {time || "--:--"}
+    <li className="flex justify-between items-start space-x-4">
+      {/* 좌측: 시간 + 내용 */}
+      <div className="flex gap-4">
+        <div className="min-w-[60px] text-sm text-gray-500 font-semibold">
+          {time || "--:--"}
+        </div>
+        <div>
+          <p className="text-sm font-medium text-gray-900">{activity}</p>
+          {description && (
+            <p className="text-sm text-gray-500 mt-1">{description}</p>
+          )}
+        </div>
       </div>
-      <div>
-        <p className="text-sm font-medium text-gray-900">{activity}</p>
-        {description && (
-          <p className="text-sm text-gray-500 mt-1">{description}</p>
-        )}
-      </div>
+
+      {/* 우측: 삭제 버튼 */}
+      {onDelete && (
+        <button
+          onClick={onDelete}
+          className="text-gray-400 hover:text-red-500 transition"
+          aria-label="세부 일정 삭제"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      )}
     </li>
   );
 }

--- a/src/components/itinerary/DayScheduleItem.jsx
+++ b/src/components/itinerary/DayScheduleItem.jsx
@@ -1,12 +1,14 @@
 export default function DayScheduleItem({ time, activity, description }) {
   return (
     <li className="flex items-start space-x-4">
-      <span className="min-w-[70px] text-sm text-gray-500 whitespace-nowrap">
-        {time}
-      </span>
+      <div className="min-w-[60px] text-sm text-gray-500 font-semibold">
+        {time || "--:--"}
+      </div>
       <div>
-        <p className="font-medium">{activity}</p>
-        {description && <p className="text-sm text-gray-500">{description}</p>}
+        <p className="text-sm font-medium text-gray-900">{activity}</p>
+        {description && (
+          <p className="text-sm text-gray-500 mt-1">{description}</p>
+        )}
       </div>
     </li>
   );

--- a/src/components/itinerary/DayScheduleList.jsx
+++ b/src/components/itinerary/DayScheduleList.jsx
@@ -73,8 +73,11 @@ export default function DayScheduleList({ days = [] }) {
             onClick={() => setOpenDay(openDay === day.day ? null : day.day)}
             className="w-full flex justify-between items-center px-4 py-3 text-left"
           >
-            <h3 className="font-semibold text-gray-800">
-              DAY {day.day} · {day.date}
+            <h3 className="text-sm sm:text-base font-semibold text-gray-900 flex items-center gap-2">
+              <span className="inline-block bg-[#6C8BA4] text-white text-xs px-2 py-1 rounded-md">
+                DAY {day.day}
+              </span>
+              <span className="text-gray-700">· {day.date}</span>
             </h3>
             <ChevronDown
               className={`w-5 h-5 transition-transform ${
@@ -98,7 +101,7 @@ export default function DayScheduleList({ days = [] }) {
               {openFormForDay !== index && (
                 <button
                   onClick={() => setOpenFormForDay(index)}
-                  className="text-sm text-blue-600 hover:underline mt-2"
+                  className="text-sm text-[#6C8BA4] hover:bg-[#f0f4f8] px-2 py-1 rounded mt-2 transition"
                 >
                   + 세부 일정 추가
                 </button>

--- a/src/components/itinerary/DayScheduleList.jsx
+++ b/src/components/itinerary/DayScheduleList.jsx
@@ -1,26 +1,122 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useAddScheduleToDay } from "services/queries/itinerary/useAddScheduleToDay";
 import DayScheduleItem from "./DayScheduleItem";
+import { ChevronDown } from "lucide-react";
 
-export default function DayScheduleList({ days }) {
-  if (!days || days.length === 0) return null;
+export default function DayScheduleList({ days = [] }) {
+  const [openDay, setOpenDay] = useState(days[0]?.day || null);
+  const [openFormForDay, setOpenFormForDay] = useState(null);
+  const [formData, setFormData] = useState({
+    time: "",
+    activity: "",
+    description: "",
+  });
+  const { id: itineraryId } = useParams();
+  const { mutate: addSchedule } = useAddScheduleToDay();
+
+  const handleFormChange = (e) => {
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleFormSubmit = (dayIndex) => {
+    if (!formData.time || !formData.activity)
+      return alert("시간과 활동은 필수입니다.");
+
+    addSchedule({
+      itineraryId,
+      dayIndex,
+      newSchedule: { ...formData },
+    });
+
+    setFormData({ time: "", activity: "", description: "" });
+    setOpenFormForDay(null);
+  };
 
   return (
-    <div className="mt-10 space-y-6">
-      {days.map((day) => (
-        <section key={day.day} className="border p-4 rounded-md">
-          <h3 className="font-semibold text-lg mb-2">
-            DAY {day.day} · {day.date}
-          </h3>
-          <ul>
-            {day.schedules.map((item, idx) => (
-              <DayScheduleItem
-                key={item.id || `${day.day}-${idx}`}
-                time={item.time}
-                activity={item.activity}
-                description={item.description}
-              />
-            ))}
-          </ul>
-        </section>
+    <div className="mt-10 space-y-4">
+      {days.map((day, index) => (
+        <div key={day.day} className="border rounded-xl">
+          {/* 헤더 */}
+          <button
+            onClick={() => setOpenDay(openDay === day.day ? null : day.day)}
+            className="w-full flex justify-between items-center px-4 py-3 text-left"
+          >
+            <h3 className="font-semibold text-gray-800">
+              DAY {day.day} · {day.date}
+            </h3>
+            <ChevronDown
+              className={`w-5 h-5 transition-transform ${
+                openDay === day.day ? "rotate-180" : ""
+              }`}
+            />
+          </button>
+
+          {/* 아코디언 내용 */}
+          {openDay === day.day && (
+            <ul className="px-6 pb-4 space-y-3">
+              {day.schedules.map((item, idx) => (
+                <DayScheduleItem
+                  key={item.id || `${day.day}-${idx}`}
+                  {...item}
+                />
+              ))}
+
+              {/* + 버튼 → 입력 폼 토글 */}
+              {openFormForDay !== index && (
+                <button
+                  onClick={() => setOpenFormForDay(index)}
+                  className="text-sm text-blue-600 hover:underline mt-2"
+                >
+                  + 세부 일정 추가
+                </button>
+              )}
+
+              {/* 입력 폼 */}
+              {openFormForDay === index && (
+                <li className="mt-3 space-y-2">
+                  <div className="flex gap-2">
+                    <input
+                      name="time"
+                      value={formData.time}
+                      onChange={handleFormChange}
+                      placeholder="시간 (예: 오전 9시)"
+                      className="border px-2 py-1 rounded w-28 text-sm"
+                    />
+                    <input
+                      name="activity"
+                      value={formData.activity}
+                      onChange={handleFormChange}
+                      placeholder="활동"
+                      className="border px-2 py-1 rounded flex-1 text-sm"
+                    />
+                  </div>
+                  <textarea
+                    name="description"
+                    value={formData.description}
+                    onChange={handleFormChange}
+                    placeholder="설명 (선택)"
+                    className="border w-full px-2 py-1 rounded text-sm"
+                  />
+                  <div className="flex gap-2 justify-end mt-1">
+                    <button
+                      onClick={() => handleFormSubmit(index)}
+                      className="bg-gray-800 text-white px-3 py-1 text-sm rounded"
+                    >
+                      저장
+                    </button>
+                    <button
+                      onClick={() => setOpenFormForDay(null)}
+                      className="text-sm text-gray-500"
+                    >
+                      취소
+                    </button>
+                  </div>
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
       ))}
     </div>
   );

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -5,10 +5,20 @@ import { useItineraryDetail } from "services/queries/itinerary/useItineraryDetai
 
 import LoadingSpinner from "components/common/LoadingSpinner";
 import NotFoundMessage from "components/common/NotFoundMessage";
-import ItineraryHero from "./ItineraryHero";
+import ItineraryHero from "components/itinerary/ItineraryHero";
 
 import DayScheduleList from "./DayScheduleList";
 import { useDeleteItinerary } from "services/queries/itinerary/useDeleteItinerary";
+import { format } from "date-fns";
+
+import {
+  MapPin,
+  CalendarDays,
+  TimerReset,
+  Eye,
+  EyeOff,
+  Quote,
+} from "lucide-react";
 
 export default function ItineraryDetail() {
   const { id } = useParams();
@@ -24,39 +34,90 @@ export default function ItineraryDetail() {
     return <NotFoundMessage message="일정을 찾을 수 없습니다." />;
 
   const isOwner = currentUser?.user?.uid === data.userId;
-  const { title, startDate, endDate, memo, location, isPublic } = data;
+  const { location, isPublic, summary } = data;
 
   return (
     <>
       <ItineraryHero data={data} isOwner={isOwner} />
-      <div className="max-w-4xl mx-auto px-4 py-10">
-        {/* 상단 제목 + 날짜 */}
-        <div className="mb-8">
-          <button
-            onClick={() => navigate("/itinerary")}
-            className="text-sm text-gray-500 mb-2 hover:underline "
-          >
-            ← 목록으로 돌아가기
-          </button>
-          <h1 className="text-3xl font-bold mb-2">{title}</h1>
+      {/* 여행 정보 */}
+      <section className="mt-10 space-y-6">
+        {/* 여행 정보 4개 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {/* 여행 지역 */}
+          <div className="bg-white border border-gray-200 rounded-xl px-6 py-4 shadow-sm">
+            <div className="flex justify-between items-center text-sm text-gray-700">
+              <span className="flex items-center font-semibold text-gray-500">
+                <MapPin className="w-4 h-4 mr-1" />
+                여행 지역
+              </span>
+              <span className="text-base text-gray-800 font-medium">
+                {location || "미정"}
+              </span>
+            </div>
+          </div>
 
-          <p className="text-gray-500">
-            {startDate} ~ {endDate} · {location}
-          </p>
-          {isPublic && (
-            <span className="text-xs text-blue-600 font-medium mt-1 inline-block">
-              공개 일정
-            </span>
-          )}
+          {/* 등록일 */}
+          <div className="bg-white border border-gray-200 rounded-xl px-6 py-4 shadow-sm">
+            <div className="flex justify-between items-center text-sm text-gray-700">
+              <span className="flex items-center font-semibold text-gray-500">
+                <CalendarDays className="w-4 h-4 mr-1" />
+                등록일
+              </span>
+              <span className="text-base text-gray-800 font-medium">
+                {data.createdAt
+                  ? format(new Date(data.createdAt), "yyyy.MM.dd")
+                  : "정보 없음"}
+              </span>
+            </div>
+          </div>
+
+          {/* 총 일정 */}
+          <div className="bg-white border border-gray-200 rounded-xl px-6 py-4 shadow-sm">
+            <div className="flex justify-between items-center text-sm text-gray-700">
+              <span className="flex items-center font-semibold text-gray-500">
+                <TimerReset className="w-4 h-4 mr-1" />총 일정
+              </span>
+              <span className="text-base text-gray-800 font-medium">
+                {data.days?.length ? `총 ${data.days.length}일` : "일정 미정"}
+              </span>
+            </div>
+          </div>
+
+          {/* 공개 여부 */}
+          <div className="bg-white border border-gray-200 rounded-xl px-6 py-4 shadow-sm">
+            <div className="flex justify-between items-center text-sm text-gray-700">
+              <span className="flex items-center font-semibold text-gray-500">
+                {isPublic ? (
+                  <Eye className="w-4 h-4 mr-1" />
+                ) : (
+                  <EyeOff className="w-4 h-4 mr-1" />
+                )}
+                일정 공개
+              </span>
+              <span
+                className={`text-base font-medium ${
+                  isPublic ? "text-blue-600" : "text-gray-500"
+                }`}
+              >
+                {isPublic ? "공개" : "비공개"}
+              </span>
+            </div>
+          </div>
         </div>
 
-        {/* 메모 or 간단한 소개 */}
-        {memo && (
-          <div className="bg-gray-50 border rounded p-4 text-gray-700">
-            {memo}
+        {/* 여행 한 줄 소개 */}
+        {summary && (
+          <div className="bg-white border border-gray-200 rounded-xl px-6 py-5 shadow-sm">
+            <h3 className="text-sm text-gray-500 font-semibold mb-2 flex items-center">
+              <Quote className="w-4 h-4 mr-1" />
+              여행 한 줄 소개
+            </h3>
+            <p className="text-base text-gray-800">{summary}</p>
           </div>
         )}
+      </section>
 
+      <div className="max-w-4xl mx-auto px-4 py-10">
         {/* 앞으로 추가될 일정 상세 / 포함사항 등은 이 아래 */}
         {data.days && <DayScheduleList days={data.days} />}
 

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -19,6 +19,7 @@ import {
   Quote,
 } from "lucide-react";
 import FloatingButtons from "components/common/FloatingButtons";
+import ChecklistSection from "./ChecklistSection";
 
 export default function ItineraryDetail() {
   const { id } = useParams();
@@ -30,8 +31,6 @@ export default function ItineraryDetail() {
     return <NotFoundMessage message="일정을 찾을 수 없습니다." />;
 
   const isOwner = currentUser?.user?.uid === data.userId;
-  console.log("currentUser.uid", currentUser?.user?.uid);
-  console.log("data.userId", data.userId);
   const { location, isPublic, summary } = data;
 
   return (
@@ -120,6 +119,8 @@ export default function ItineraryDetail() {
         {data.days && <DayScheduleList days={data.days} />}
 
         {isOwner && <FloatingButtons />}
+
+        {isOwner && <ChecklistSection checklist={data.checklist} />}
       </section>
     </>
   );

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -5,6 +5,8 @@ import { useItineraryDetail } from "services/queries/itinerary/useItineraryDetai
 
 import LoadingSpinner from "components/common/LoadingSpinner";
 import NotFoundMessage from "components/common/NotFoundMessage";
+import ItineraryHero from "./ItineraryHero";
+
 import DayScheduleList from "./DayScheduleList";
 import { useDeleteItinerary } from "services/queries/itinerary/useDeleteItinerary";
 
@@ -25,59 +27,62 @@ export default function ItineraryDetail() {
   const { title, startDate, endDate, memo, location, isPublic } = data;
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-10">
-      {/* 상단 제목 + 날짜 */}
-      <div className="mb-8">
-        <button
-          onClick={() => navigate("/itinerary")}
-          className="text-sm text-gray-500 mb-2 hover:underline "
-        >
-          ← 목록으로 돌아가기
-        </button>
-        <h1 className="text-3xl font-bold mb-2">{title}</h1>
+    <>
+      <ItineraryHero data={data} isOwner={isOwner} />
+      <div className="max-w-4xl mx-auto px-4 py-10">
+        {/* 상단 제목 + 날짜 */}
+        <div className="mb-8">
+          <button
+            onClick={() => navigate("/itinerary")}
+            className="text-sm text-gray-500 mb-2 hover:underline "
+          >
+            ← 목록으로 돌아가기
+          </button>
+          <h1 className="text-3xl font-bold mb-2">{title}</h1>
 
-        <p className="text-gray-500">
-          {startDate} ~ {endDate} · {location}
-        </p>
-        {isPublic && (
-          <span className="text-xs text-blue-600 font-medium mt-1 inline-block">
-            공개 일정
-          </span>
+          <p className="text-gray-500">
+            {startDate} ~ {endDate} · {location}
+          </p>
+          {isPublic && (
+            <span className="text-xs text-blue-600 font-medium mt-1 inline-block">
+              공개 일정
+            </span>
+          )}
+        </div>
+
+        {/* 메모 or 간단한 소개 */}
+        {memo && (
+          <div className="bg-gray-50 border rounded p-4 text-gray-700">
+            {memo}
+          </div>
+        )}
+
+        {/* 앞으로 추가될 일정 상세 / 포함사항 등은 이 아래 */}
+        {data.days && <DayScheduleList days={data.days} />}
+
+        {isOwner && (
+          <div className="flex justify-end mt-12">
+            <button
+              onClick={() => navigate(`/itinerary/edit/${data.id}`)}
+              className="bg-gray-900 text-white px-6 py-2 rounded-lg mr-2 hover:bg-gray-800 transition"
+            >
+              수정하기
+            </button>
+
+            <button
+              onClick={() => {
+                if (confirm("정말로 이 일정을 삭제하시겠습니까?")) {
+                  deleteMutate(data.id);
+                }
+              }}
+              disabled={isDeleting}
+              className="text-sm text-red-600 border border-red-600 px-6 py-2 rounded-lg hover:bg-red-50"
+            >
+              {isDeleting ? "삭제 중..." : "삭제하기"}
+            </button>
+          </div>
         )}
       </div>
-
-      {/* 메모 or 간단한 소개 */}
-      {memo && (
-        <div className="bg-gray-50 border rounded p-4 text-gray-700">
-          {memo}
-        </div>
-      )}
-
-      {/* 앞으로 추가될 일정 상세 / 포함사항 등은 이 아래 */}
-      {data.days && <DayScheduleList days={data.days} />}
-
-      {isOwner && (
-        <div className="flex justify-end mt-12">
-          <button
-            onClick={() => navigate(`/itinerary/edit/${data.id}`)}
-            className="bg-gray-900 text-white px-6 py-2 rounded-lg mr-2 hover:bg-gray-800 transition"
-          >
-            수정하기
-          </button>
-
-          <button
-            onClick={() => {
-              if (confirm("정말로 이 일정을 삭제하시겠습니까?")) {
-                deleteMutate(data.id);
-              }
-            }}
-            disabled={isDeleting}
-            className="text-sm text-red-600 border border-red-600 px-6 py-2 rounded-lg hover:bg-red-50"
-          >
-            {isDeleting ? "삭제 중..." : "삭제하기"}
-          </button>
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -117,7 +117,7 @@ export default function ItineraryDetail() {
         )}
       </section>
 
-      <div className="max-w-4xl mx-auto px-4 py-10">
+      <section className="mt-10 space-y-6">
         {/* 앞으로 추가될 일정 상세 / 포함사항 등은 이 아래 */}
         {data.days && <DayScheduleList days={data.days} />}
 
@@ -143,7 +143,7 @@ export default function ItineraryDetail() {
             </button>
           </div>
         )}
-      </div>
+      </section>
     </>
   );
 }

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 import { useItineraryDetail } from "services/queries/itinerary/useItineraryDetail";
@@ -8,7 +8,6 @@ import NotFoundMessage from "components/common/NotFoundMessage";
 import ItineraryHero from "components/itinerary/ItineraryHero";
 
 import DayScheduleList from "./DayScheduleList";
-import { useDeleteItinerary } from "services/queries/itinerary/useDeleteItinerary";
 import { format } from "date-fns";
 
 import {
@@ -19,13 +18,10 @@ import {
   EyeOff,
   Quote,
 } from "lucide-react";
+import FloatingButtons from "components/common/FloatingButtons";
 
 export default function ItineraryDetail() {
   const { id } = useParams();
-  const navigate = useNavigate();
-
-  const { mutate: deleteMutate, isPending: isDeleting } = useDeleteItinerary();
-
   const currentUser = useSelector((state) => state.user);
   const { data, isLoading, isError } = useItineraryDetail(id);
 
@@ -34,6 +30,8 @@ export default function ItineraryDetail() {
     return <NotFoundMessage message="일정을 찾을 수 없습니다." />;
 
   const isOwner = currentUser?.user?.uid === data.userId;
+  console.log("currentUser.uid", currentUser?.user?.uid);
+  console.log("data.userId", data.userId);
   const { location, isPublic, summary } = data;
 
   return (
@@ -121,28 +119,7 @@ export default function ItineraryDetail() {
         {/* 앞으로 추가될 일정 상세 / 포함사항 등은 이 아래 */}
         {data.days && <DayScheduleList days={data.days} />}
 
-        {isOwner && (
-          <div className="flex justify-end mt-12">
-            <button
-              onClick={() => navigate(`/itinerary/edit/${data.id}`)}
-              className="bg-gray-900 text-white px-6 py-2 rounded-lg mr-2 hover:bg-gray-800 transition"
-            >
-              수정하기
-            </button>
-
-            <button
-              onClick={() => {
-                if (confirm("정말로 이 일정을 삭제하시겠습니까?")) {
-                  deleteMutate(data.id);
-                }
-              }}
-              disabled={isDeleting}
-              className="text-sm text-red-600 border border-red-600 px-6 py-2 rounded-lg hover:bg-red-50"
-            >
-              {isDeleting ? "삭제 중..." : "삭제하기"}
-            </button>
-          </div>
-        )}
+        {isOwner && <FloatingButtons />}
       </section>
     </>
   );

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -58,21 +58,7 @@ export default function ItineraryForm({ initialData, isEditMode = false }) {
       summary,
       isPublic,
       userId: user.uid,
-      days: initialData?.days || [
-        {
-          day: 1,
-          date: startDate,
-          schedules: [
-            { time: "오전", activity: "도착", description: "목적지 도착" },
-            { time: "오후", activity: "관광", description: "주요 관광지 방문" },
-            {
-              time: "저녁",
-              activity: "저녁 식사",
-              description: "현지 맛집 방문",
-            },
-          ],
-        },
-      ],
+      days: [],
     };
 
     isEditMode

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -58,7 +58,8 @@ export default function ItineraryForm({ initialData, isEditMode = false }) {
       summary,
       isPublic,
       userId: user.uid,
-      days: [],
+      days: initialData?.days || [],
+      checklist: initialData?.checklist || { required: [], optional: [] },
     };
 
     isEditMode

--- a/src/components/itinerary/ItineraryHero.jsx
+++ b/src/components/itinerary/ItineraryHero.jsx
@@ -1,0 +1,46 @@
+import { format } from "date-fns";
+import { Calendar } from "lucide-react";
+
+export default function ItineraryHero({ data }) {
+  const { title, imageUrl, startDate, endDate, createdBy } = data || {};
+
+  const formattedPeriod =
+    startDate && endDate
+      ? `${format(new Date(startDate), "yyyy.MM.dd")} ~ ${format(
+          new Date(endDate),
+          "yyyy.MM.dd"
+        )}`
+      : "여행 날짜 미정";
+
+  return (
+    <div className="relative h-[420px] w-full rounded-3xl overflow-hidden">
+      <img
+        src={imageUrl || "/images/no_image.png"}
+        alt={title}
+        className="absolute inset-0 w-full h-full object-cover"
+      />
+      <div className="absolute inset-0 bg-black/50" />
+
+      <div className="relative z-10 max-w-6xl mx-auto px-6 h-full flex flex-col justify-end pb-9 text-white">
+        <div className="flex items-center gap-2 text-sm opacity-90">
+          <Calendar className="w-4 h-4" />
+          <span>{formattedPeriod}</span>
+        </div>
+
+        <h1 className="text-4xl font-bold mt-3">{title}</h1>
+
+        {/* 작성자 */}
+        {createdBy && (
+          <div className="flex items-center gap-2 mt-4 text-sm text-white/70">
+            <img
+              src={createdBy.photoURL || "/default_profile.png"}
+              alt="작성자"
+              className="w-6 h-6 rounded-full object-cover"
+            />
+            <span>{createdBy.displayName || "익명"}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/itinerary/Detail.jsx
+++ b/src/pages/itinerary/Detail.jsx
@@ -1,5 +1,10 @@
+import LayoutWrapper from "components/common/LayoutWrapper";
 import ItineraryDetail from "components/itinerary/ItineraryDetail";
 
 export default function ItineraryDetailPage() {
-  return <ItineraryDetail />;
+  return (
+    <LayoutWrapper>
+      <ItineraryDetail />
+    </LayoutWrapper>
+  );
 }

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -1,3 +1,4 @@
+import { eachDayOfInterval, format } from "date-fns";
 import { db } from "./firebase";
 import {
   collection,
@@ -35,6 +36,19 @@ export const createItinerary = async (itineraryData) => {
       throw new Error("필수 정보가 누락되었습니다.");
     }
 
+    const generatedDays =
+      days.length > 0
+        ? days
+        : eachDayOfInterval({
+            start: new Date(startDate),
+            end: new Date(endDate),
+          }).map((date, index) => ({
+            day: index + 1,
+            title: "", // 추후 수정 가능
+            date: format(date, "yyyy-MM-dd"),
+            schedules: [],
+          }));
+
     const docRef = await addDoc(collection(db, "itineraries"), {
       title,
       location,
@@ -44,7 +58,7 @@ export const createItinerary = async (itineraryData) => {
       imageUrl,
       createdBy,
       isPublic,
-      days,
+      days: generatedDays,
       checklist,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -203,3 +203,11 @@ export const deleteItinerary = async (id) => {
     throw error;
   }
 };
+
+export const updateChecklist = async (itineraryId, checklist) => {
+  const docRef = doc(db, "itineraries", itineraryId);
+  await updateDoc(docRef, {
+    checklist,
+    updatedAt: serverTimestamp(),
+  });
+};

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -57,6 +57,7 @@ export const createItinerary = async (itineraryData) => {
       summary,
       imageUrl,
       createdBy,
+      userId: createdBy.uid,
       isPublic,
       days: generatedDays,
       checklist,

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -25,6 +25,9 @@ export const createItinerary = async (itineraryData) => {
       summary,
       imageUrl = "",
       createdBy,
+      isPublic = false,
+      days = [],
+      checklist = { required: [], optional: [] },
     } = itineraryData;
 
     // 필수 필드 검증
@@ -39,7 +42,10 @@ export const createItinerary = async (itineraryData) => {
       endDate,
       summary,
       imageUrl,
-      createdBy, // 작성자 정보 객체 전체 저장
+      createdBy,
+      isPublic,
+      days,
+      checklist,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     });

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -57,6 +57,41 @@ export const createItinerary = async (itineraryData) => {
   }
 };
 
+// 특정 일자의 일정(schedules)에 새로운 일정 하나 추가
+export const addScheduleToDay = async (itineraryId, dayIndex, newSchedule) => {
+  try {
+    const itineraryRef = doc(db, "itineraries", itineraryId);
+    const docSnap = await getDoc(itineraryRef);
+
+    if (!docSnap.exists()) {
+      throw new Error("존재하지 않는 일정입니다.");
+    }
+
+    const data = docSnap.data();
+    const updatedDays = [...(data.days || [])];
+
+    if (!updatedDays[dayIndex]) {
+      throw new Error(`DAY ${dayIndex + 1}가 존재하지 않습니다.`);
+    }
+
+    // 새로운 세부 일정 추가
+    updatedDays[dayIndex].schedules.push({
+      ...newSchedule,
+      id: Date.now().toString(), // 간단한 고유 ID 생성
+    });
+
+    await updateDoc(itineraryRef, {
+      days: updatedDays,
+      updatedAt: serverTimestamp(),
+    });
+
+    return true;
+  } catch (error) {
+    console.error("세부 일정 추가 중 오류 발생:", error);
+    throw error;
+  }
+};
+
 // 사용자 일정 목록 조회 함수
 export const fetchUserItineraries = async (uid, maxResults = 20) => {
   try {

--- a/src/services/queries/itinerary/useAddScheduleToDay.js
+++ b/src/services/queries/itinerary/useAddScheduleToDay.js
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addScheduleToDay } from "services/itineraryService";
+
+export function useAddScheduleToDay() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ itineraryId, dayIndex, newSchedule }) =>
+      addScheduleToDay(itineraryId, dayIndex, newSchedule),
+
+    onSuccess: (_, { itineraryId }) => {
+      // 일정 상세 캐시 무효화
+      queryClient.invalidateQueries(["itineraryDetail", itineraryId]);
+    },
+
+    onError: (error) => {
+      console.error("세부 일정 추가 실패:", error);
+      alert("세부 일정을 추가하는 도중 오류가 발생했습니다.");
+    },
+  });
+}


### PR DESCRIPTION
#### 주요 변경 사항
- ItineraryHero 컴포넌트 분리 및 LayoutWrapper 공통 레이아웃 컴포넌트 생성
- 일정 상세 페이지에 여행 정보 섹션 추가 (지역, 등록일, 공개 여부 등 표시)
-  일정 생성 시 days, checklist, isPublic 필드 저장 로직 추가
- 일정 상세 페이지에 일자별 세부 일정 표시, 토글 아코디언 UI 적용
- 세부 일정 추가/삭제 기능 구현 및 Firebase 자동 업데이트 반영
- 여행 준비 체크리스트 UI 구성 (필수/선택 항목 분리 및 체크박스 추가)
- 체크리스트 자동 저장 기능 추가 (debounce 적용)
- 필수/선택 준비물을 2단 카드 레이아웃으로 가로 정렬 (반응형 대응)

#### 기타 수정 사항
- Firebase 보안 규칙 수정: createdBy.uid 기반으로 권한 판단
- 일정 수정 시 기존 days, checklist 필드가 누락되는 이슈 해결
- 세부 일정 항목에 감성적 아이콘 및 체크 스타일 적용
