### PR TITLE
feat: 일정 이미지 업로드 기능 및 공통 컴포넌트 ImageUploader 적용

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,8 +21,7 @@ service cloud.firestore {
     match /itineraries/{itineraryId} {
       allow read: if isSignedIn();
       allow create: if isSignedIn();
-      allow update: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
-      allow delete: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
+      allow update, delete: if isSignedIn() && resource.data.userId == request.auth.uid;
     }
 
     match /reviews/{reviewId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -21,7 +21,7 @@ service cloud.firestore {
     match /itineraries/{itineraryId} {
       allow read: if isSignedIn();
       allow create: if isSignedIn();
-      allow update, delete: if isSignedIn() && resource.data.userId == request.auth.uid;
+      allow update, delete: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
     }
 
     match /reviews/{reviewId} {

--- a/src/components/common/ImageUploader.jsx
+++ b/src/components/common/ImageUploader.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { ImageIcon } from "lucide-react";
+
+export default function ImageUploader({ imageFile, onChange }) {
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    if (!imageFile) return setPreviewUrl(null);
+    const objectUrl = URL.createObjectURL(imageFile);
+    setPreviewUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [imageFile]);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/") || file.size > 5 * 1024 * 1024) {
+      alert("5MB 이하의 이미지 파일만 업로드 가능합니다.");
+      return;
+    }
+    onChange(file);
+  };
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700">
+        대표 이미지 (선택)
+      </label>
+      <div className="mt-2 border-2 border-dashed border-gray-300 rounded-md p-6 text-center text-sm text-gray-500">
+        {previewUrl ? (
+          <img
+            src={previewUrl}
+            alt="미리보기"
+            className="w-32 h-32 object-cover rounded-lg mx-auto"
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center">
+            <ImageIcon className="w-6 h-6 mb-2 text-gray-400" />
+            여행을 표현할 수 있는 이미지를 업로드해주세요
+          </div>
+        )}
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm"
+          >
+            이미지 선택
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -7,6 +7,7 @@ import { updateItinerary } from "services/itineraryService";
 import DatePicker from "./DatePicker";
 import FormSubmitButton from "components/common/FormSubmitButton";
 import { BookOpenText, Camera, Clock, ImageIcon, MapPin } from "lucide-react";
+import ImageUploader from "components/common/ImageUploader";
 
 export default function ItineraryForm({ initialData, isEditMode = false }) {
   const [title, setTitle] = useState(initialData?.title || "");
@@ -16,6 +17,7 @@ export default function ItineraryForm({ initialData, isEditMode = false }) {
   const [summary, setSummary] = useState(initialData?.summary || "");
   const [isPublic, setIsPublic] = useState(initialData?.isPublic || true);
   const [errors, setErrors] = useState({});
+  const [imageFile, setImageFile] = useState(null);
 
   const navigate = useNavigate();
   const { mutate: addMutate, isPending: isAdding } = useAddItinerary();
@@ -187,26 +189,8 @@ export default function ItineraryForm({ initialData, isEditMode = false }) {
             </div>
           </div>
 
-          {/* 대표 이미지 업로드 (아직 기능 없음) */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700">
-              대표 이미지 (선택)
-            </label>
-            <div className="mt-2 border-2 border-dashed border-gray-300 rounded-md p-6 text-center text-sm text-gray-500">
-              <div className="flex flex-col items-center justify-center">
-                <ImageIcon className="w-6 h-6 mb-2 text-gray-400" />
-                여행을 표현할 수 있는 이미지를 업로드해주세요
-                <div className="mt-3">
-                  <button
-                    type="button"
-                    className="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm"
-                  >
-                    이미지 선택
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
+          {/* 대표 이미지 업로드*/}
+          <ImageUploader imageFile={imageFile} onChange={setImageFile} />
 
           {/* 제출 버튼 */}
           <div className="flex justify-end">

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -62,6 +62,7 @@ export default function ItineraryForm({ initialData, isEditMode = false }) {
       userId: user.uid,
       days: initialData?.days || [],
       checklist: initialData?.checklist || { required: [], optional: [] },
+      image: imageFile,
     };
 
     isEditMode

--- a/src/services/queries/itinerary/useAddItinerary.js
+++ b/src/services/queries/itinerary/useAddItinerary.js
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import { updateDoc, doc, increment } from "firebase/firestore";
 import { db } from "services/firebase";
 import { createItinerary } from "services/itineraryService";
+import { uploadImage } from "utils/uploadImage";
 
 /**
  * 일정 생성 훅
@@ -22,8 +23,21 @@ export const useAddItinerary = ({
   return useMutation({
     mutationFn: async (formData) => {
       if (!user) throw new Error("로그인이 필요합니다.");
+
+      let imageUrl = "";
+
+      if (formData.image) {
+        try {
+          imageUrl = await uploadImage(formData.image, "itineraries");
+          console.log(imageUrl);
+        } catch (err) {
+          throw new Error(err.message);
+        }
+      }
+
       const itineraryData = {
         ...formData,
+        imageUrl,
         createdBy: {
           uid: user.uid,
           displayName: user.displayName || "익명",

--- a/src/services/queries/review/useAddReview.js
+++ b/src/services/queries/review/useAddReview.js
@@ -1,25 +1,25 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { db, storage } from "../../firebase";
-import {
-  addDoc,
-  collection,
-  doc,
-  increment,
-  serverTimestamp,
-  updateDoc,
-} from "firebase/firestore";
-import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
+import {
+  updateDoc,
+  doc,
+  increment,
+  addDoc,
+  collection,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "services/firebase";
+import { uploadImage } from "utils/uploadImage";
 
 /**
-+ * 리뷰 추가 기능을 제공하는 커스텀 훅
-+ * @param {Object} options - 훅 옵션
-+ * @param {Function} options.onSuccessCallback - 리뷰 추가 성공 시 호출되는 콜백 함수
-+ * @param {Function} options.onErrorCallback - 리뷰 추가 실패 시 호출되는 콜백 함수(에러 객체를 매개변수로 받음)
-+ * @returns {Object} 리뷰 추가 관련 함수와 상태
-+ */
-export default function useAddReview({
+ * 일정 추가 기능을 제공하는 커스텀 훅
+ * @param {Object} options - 훅 옵션
+ * @param {Function} options.onSuccessCallback - 성공 시 콜백
+ * @param {Function} options.onErrorCallback - 실패 시 콜백
+ * @returns {Object} 일정 추가 관련 함수와 상태
+ */
+export default function useAddItinerary({
   onSuccessCallback = () => {},
   onErrorCallback = () => {},
 } = {}) {
@@ -27,80 +27,76 @@ export default function useAddReview({
   const user = useSelector((state) => state.user.user);
   const queryClient = useQueryClient();
 
-  // 사용자 인증 상태 확인
   const checkAuth = () => {
     if (!user) {
-      navigate("/login", { state: { from: "/reviews/create" } });
+      navigate("/login", { state: { from: "/itinerary/create" } });
       throw new Error("로그인이 필요한 서비스입니다.");
     }
   };
 
   const {
-    mutate: addReview, // mutate → addReview로 이름 변경
-    isLoading, // 외부에서 로딩 상태 사용할 수 있도록 반환
+    mutate: addItinerary,
+    isLoading,
     isError,
     error,
   } = useMutation({
-    mutationFn: async ({ title, destination, content, rating, image }) => {
+    mutationFn: async ({
+      title,
+      destination,
+      description,
+      image,
+      isPublic = true,
+      oneLineIntro = "",
+    }) => {
       checkAuth();
       if (!title?.trim()) throw new Error("제목을 입력해주세요.");
       if (!destination?.trim()) throw new Error("여행지를 입력해주세요.");
-      if (!content?.trim()) throw new Error("내용을 입력해주세요.");
 
       let imageUrl = "";
 
       if (image) {
-        const maxSizeInBytes = 5 * 1024 * 1024;
-        const allowedTypes = ["image/jpeg", "image/png", "image/gif"];
-
-        if (image.size > maxSizeInBytes) {
-          throw new Error("이미지 크기는 5MB 이하이어야 합니다.");
-        }
-        if (!allowedTypes.includes(image.type)) {
-          throw new Error("지원되는 이미지 형식은 JPEG, PNG, GIF입니다.");
-        }
-
-        const imageRef = ref(storage, `reviews/${Date.now()}_${image.name}`);
         try {
-          const snapshot = await uploadBytes(imageRef, image);
-          imageUrl = await getDownloadURL(snapshot.ref);
-        } catch (error) {
-          console.error("이미지 업로드 중 오류 발생:", error);
-          throw new Error("이미지 업로드에 실패했습니다. 다시 시도해 주세요.");
+          imageUrl = await uploadImage(image, "itineraries");
+        } catch (err) {
+          throw new Error(err.message);
         }
       }
 
-      await addDoc(collection(db, "reviews"), {
+      await addDoc(collection(db, "itineraries"), {
         title,
         destination,
-        content,
-        rating,
+        description,
         imageUrl,
-        authorId: user?.uid || "",
-        authorName: user?.displayName || "익명",
+        isPublic,
+        oneLineIntro,
+        createdBy: {
+          uid: user.uid,
+          displayName: user.displayName || "익명",
+          photoURL: user.photoURL || "",
+        },
         createdAt: serverTimestamp(),
-        likesCount: 0,
+        likeCount: 0,
       });
 
       await updateDoc(doc(db, "users", user.uid), {
-        reviewCount: increment(1),
+        itineraryCount: increment(1),
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["reviews"] });
-      alert("리뷰가 성공적으로 등록되었습니다!");
-      navigate("/reviews");
+      queryClient.invalidateQueries({ queryKey: ["itineraries"] });
+      alert("일정이 성공적으로 등록되었습니다!");
+      navigate("/itinerary");
       onSuccessCallback();
     },
     onError: (error) => {
       console.error(error);
-      alert(`리뷰 등록 중 오류가 발생했습니다: ${error.message}`);
+      alert(`일정 등록 중 오류가 발생했습니다: ${error.message}`);
       onErrorCallback(error);
     },
   });
 
   return {
-    addReview,
+    addItinerary,
     isLoading,
     isError,
     error,

--- a/src/utils/uploadImage.js
+++ b/src/utils/uploadImage.js
@@ -1,0 +1,34 @@
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { storage } from "services/firebase";
+
+/**
+ * 이미지를 Firebase Storage에 업로드하고 다운로드 URL 반환
+ * @param {File} image - 업로드할 이미지 파일
+ * @param {string} folder - 저장할 폴더 이름 (예: 'reviews', 'itineraries')
+ * @returns {Promise<string>} - 업로드된 이미지의 다운로드 URL
+ */
+export const uploadImage = async (image, folder = "uploads", userUid) => {
+  const maxSizeInBytes = 5 * 1024 * 1024;
+  const allowedTypes = ["image/jpeg", "image/png", "image/gif"];
+
+  if (image.size > maxSizeInBytes) {
+    throw new Error("이미지 크기는 5MB 이하이어야 합니다.");
+  }
+
+  if (!allowedTypes.includes(image.type)) {
+    throw new Error("지원되는 이미지 형식은 JPEG, PNG, GIF입니다.");
+  }
+
+  const imageRef = ref(
+    storage,
+    `${folder}/${userUid}/${Date.now()}_${image.name}`
+  );
+
+  try {
+    const snapshot = await uploadBytes(imageRef, image);
+    return await getDownloadURL(snapshot.ref);
+  } catch (error) {
+    console.error("이미지 업로드 실패:", error);
+    throw new Error("이미지 업로드에 실패했습니다. 다시 시도해주세요.");
+  }
+};

--- a/storage.rules
+++ b/storage.rules
@@ -2,9 +2,9 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
 
-    // 일정 관련 파일 - 사용자 본인만 접근 가능
-    match /itineraries/{userId}/{itineraryId}/{fileName} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+    // 일정 관련 파일
+    match /itineraries/{allPaths=**} {
+      allow read, write: if request.auth != null;
     }
 
     // 리뷰 이미지 업로드 - 로그인된 유저 모두 가능


### PR DESCRIPTION
## 주요 변경사항

### 공통 이미지 업로드 컴포넌트 분리
- `ImageUploader.js` 생성하여 리뷰/일정 등에서 재사용 가능하도록 구성
- 이미지 미리보기, 용량(5MB) 및 타입(JPEG/PNG/GIF) 유효성 검사 로직 포함
- 내부적으로 `file input`을 숨기고 커스텀 UI로 파일 선택 기능 제공

### 일정 등록 시 이미지 업로드 기능 적용
- `useAddItinerary` 훅에서 `uploadImage` 유틸 함수 호출
- 이미지가 선택된 경우 Firebase Storage에 업로드 후 다운로드 URL을 Firestore에 저장
- `ItineraryForm`에서 `imageFile` 상태 관리 후 `formData`에 포함시켜 전달

### Firebase Storage 보안 규칙 업데이트
- 기존: `userUid` 기반 경로로 제한
- 변경: 모든 인증된 사용자가 `itineraries/**` 경로에 업로드 가능하도록 완화
- 이에 따라 `uploadImage` 경로 구성도 `userUid` 없이 간단하게 변경

## 참고
- 추후 리뷰 작성 기능에도 동일한 컴포넌트 및 유틸 함수 적용 예정