### PR TITLE
feat: 리뷰 목록 페이지 리디자인 및 UI 구조 통일

### DIFF
--- a/src/components/common/CreateCard.jsx
+++ b/src/components/common/CreateCard.jsx
@@ -1,17 +1,26 @@
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";
+import PropTypes from "prop-types";
 
-export default function CreateItineraryCard() {
+/**
+ * 생성 카드 공통 컴포넌트
+ *
+ * @param {string} to - 이동할 경로
+ * @param {string} title - 강조 텍스트
+ * @param {string} description - 서브 텍스트
+ * @param {string} buttonLabel - 버튼 텍스트
+ */
+export default function CreateCard({ to, title, description, buttonLabel }) {
   const navigate = useNavigate();
 
   return (
     <div
-      onClick={() => navigate("/itinerary/create")}
+      onClick={() => navigate(to)}
       role="button"
       tabIndex="0"
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
-          navigate("/itinerary/create");
+          navigate(to);
         }
       }}
       className="group bg-white border border-dashed border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden cursor-pointer flex items-center justify-center text-center px-6 py-16"
@@ -20,18 +29,21 @@ export default function CreateItineraryCard() {
         <div className="flex justify-center mb-2">
           <Plus className="w-6 h-6 text-gray-400" />
         </div>
-        <p className="text-sm font-semibold text-gray-700">
-          나만의 여행 일정 만들기
-        </p>
-        <p className="text-xs text-gray-400 mt-1">
-          당신만의 특별한 여행 계획을 시작해보세요
-        </p>
+        <p className="text-sm font-semibold text-gray-700">{title}</p>
+        <p className="text-xs text-gray-400 mt-1">{description}</p>
         <div className="mt-4">
           <button className="px-4 py-1.5 bg-black text-white text-sm rounded-full hover:bg-gray-800 transition">
-            일정 만들기
+            {buttonLabel}
           </button>
         </div>
       </div>
     </div>
   );
 }
+
+CreateCard.propTypes = {
+  to: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+};

--- a/src/components/itinerary/ItineraryList.jsx
+++ b/src/components/itinerary/ItineraryList.jsx
@@ -5,7 +5,7 @@ import ItineraryCard from "./ItineraryCard";
 import LoadingSpinner from "components/common/LoadingSpinner";
 import EmptyState from "components/common/EmptyState";
 import { Search } from "lucide-react";
-import CreateItineraryCard from "components/itinerary/CreateItineraryCard";
+import CreateCard from "components/common/CreateCard";
 
 const FILTERS = ["전체", "최신순", "과거순"];
 
@@ -113,7 +113,12 @@ export default function ItineraryList() {
       <section className="max-w-7xl mx-auto px-6 md:px-12 py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {/* 항상 표시되는 일정 생성 카드 */}
-          <CreateItineraryCard />
+          <CreateCard
+            to="/itinerary/create"
+            title="나만의 여행 일정 만들기"
+            description="당신만의 특별한 여행 계획을 시작해보세요"
+            buttonLabel="일정 만들기"
+          />
 
           {/* 일정 목록이 있으면 나열, 없으면 빈 상태 메시지 카드 형태로 */}
           {filteredItineraries.length > 0 ? (

--- a/src/components/review/ReviewCard.jsx
+++ b/src/components/review/ReviewCard.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import LikeButton from "./LikeButton";
+import LikeButton from "components/review/LikeButton";
 
 /**
  * 리뷰 정보를 카드 형태로 표시하는 컴포넌트
@@ -27,9 +27,14 @@ export default function ReviewCard({ review }) {
     authorName,
     createdAt,
     imageUrl,
+    authorPhotoURL,
   } = review || {};
 
-  const formattedDate = createdAt?.toDate?.().toLocaleDateString("ko-KR") ?? "";
+  const formattedDate =
+    createdAt instanceof Date
+      ? createdAt.toLocaleDateString("ko-KR")
+      : createdAt?.toDate?.().toLocaleDateString("ko-KR") ?? "";
+
   const truncatedContent =
     content && content.length > 100 ? `${content.slice(0, 100)}...` : content;
 
@@ -43,37 +48,73 @@ export default function ReviewCard({ review }) {
           navigate(`/reviews/${id}`);
         }
       }}
-      className="bg-white rounded-2xl shadow-md hover:shadow-lg transition duration-300 cursor-pointer overflow-hidden"
+      className="group bg-white rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden cursor-pointer"
     >
-      <img
-        src={imageUrl || "/images/no_image.png"}
-        alt={`${title} - ${destination} 리뷰 이미지`}
-        onError={(e) => {
-          e.target.onerror = null;
-          e.target.src = "/images/no_image.png"; // public 폴더 기준 경로
-        }}
-        className="w-full h-48 object-cover bg-gray-100"
-      />
+      {/* 이미지 썸네일 */}
+      <div className="relative h-56">
+        <img
+          src={imageUrl || "/images/no_image.png"}
+          alt={`${title} 썸네일`}
+          className="w-full h-full object-cover bg-gray-100"
+          onError={(e) => {
+            e.target.onerror = null;
+            e.target.src = "/images/no_image.png";
+          }}
+        />
+        {/* 여행지 태그 */}
+        <span className="absolute bottom-3 right-3 bg-black/60 text-white text-xs px-3 py-1 rounded-full">
+          {destination || "여행지 미정"}
+        </span>
+      </div>
 
-      <div className="p-5">
-        <h2 className="text-lg font-bold text-gray-800 mb-1">{title}</h2>
-        <p className="text-sm text-gray-500 mb-2">{destination}</p>
-        <div className="flex text-sm mb-2">
-          {[...Array(5)].map((_, i) => (
-            <span
-              key={i}
-              className={i < rating ? "text-yellow-500" : "text-gray-300"}
-            >
-              ★
-            </span>
-          ))}
-        </div>
-        {/* 하단 정보 + 좋아요 버튼 */}
-        <div className="flex justify-between items-center text-xs text-gray-400">
-          <span>{authorName || "익명"}</span>
-          <div className="flex items-center gap-2">
-            <LikeButton reviewId={id} />
+      {/* 본문 */}
+      <div className="p-4 space-y-1">
+        {/* 별점 + 작성일 */}
+        <div className="flex justify-between items-center text-sm text-gray-600 mb-1">
+          <div className="flex">
+            {[...Array(5)].map((_, i) => (
+              <span
+                key={i}
+                className={i < rating ? "text-yellow-500" : "text-gray-300"}
+              >
+                ★
+              </span>
+            ))}
           </div>
+
+          <span className="text-xs text-gray-400">{formattedDate}</span>
+        </div>
+
+        {/* 제목 */}
+        <h3 className="text-base font-semibold text-gray-900 line-clamp-1">
+          {title || "제목 없음"}
+        </h3>
+
+        {/* 내용 요약 */}
+        <p className="text-sm text-gray-500 line-clamp-2">
+          {truncatedContent || "리뷰 내용이 없습니다."}
+        </p>
+
+        {/* 작성자 + 좋아요 */}
+        <div className="flex justify-between items-center mt-2">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 truncate max-w-[100px]">
+              {authorName || "익명"}
+            </span>
+            <img
+              src={authorPhotoURL || "/default_profile.png"}
+              alt="작성자"
+              className="w-5 h-5 rounded-full object-cover"
+              onError={(e) => {
+                const fallback = "/default_profile.png";
+                if (!e.target.dataset.errorHandled) {
+                  e.target.src = fallback;
+                  e.target.dataset.errorHandled = "true";
+                }
+              }}
+            />
+          </div>
+          <LikeButton reviewId={id} />
         </div>
       </div>
     </div>

--- a/src/components/review/ReviewList.jsx
+++ b/src/components/review/ReviewList.jsx
@@ -1,18 +1,42 @@
-import { useState } from "react";
-
+import { useState, useMemo } from "react";
 import { useReviews } from "services/queries/review/useReviews";
 
 import ReviewCard from "./ReviewCard";
 import LoadingSpinner from "components/common/LoadingSpinner";
 import EmptyState from "components/common/EmptyState";
-import ReviewSortButtons from "./ReviewSortButtons";
+import { Search } from "lucide-react";
 
 export default function ReviewList() {
-  const [sort, setSort] = useState("latest"); // 정렬 상태
+  const [sort, setSort] = useState("latest");
+  const [searchKeyword, setSearchKeyword] = useState("");
+
   const { data: reviews, isLoading, error } = useReviews();
 
-  if (isLoading) return <LoadingSpinner />;
+  const filteredReviews = useMemo(() => {
+    if (!reviews) return [];
 
+    let result = [...reviews];
+
+    // 정렬
+    if (sort === "latest") {
+      result.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    } else if (sort === "rating") {
+      result.sort((a, b) => b.rating - a.rating);
+    }
+
+    // 검색
+    if (searchKeyword.trim()) {
+      result = result.filter((r) =>
+        r.destination
+          ?.toLowerCase()
+          .includes(searchKeyword.trim().toLowerCase())
+      );
+    }
+
+    return result;
+  }, [reviews, sort, searchKeyword]);
+
+  if (isLoading) return <LoadingSpinner />;
   if (error)
     return (
       <EmptyState
@@ -22,36 +46,80 @@ export default function ReviewList() {
       />
     );
 
-  if (!reviews || reviews.length === 0)
-    return (
-      <EmptyState
-        icon="📝"
-        title="등록된 리뷰가 없습니다"
-        description="다녀온 여행의 후기를 남겨보세요!"
-      />
-    );
-
-  // 정렬 함수 추가
-  const sortReviews = (reviews, sortType) => {
-    if (sortType === "latest") {
-      return [...reviews].sort(
-        (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
-      );
-    } else if (sortType === "rating") {
-      return [...reviews].sort((a, b) => b.rating - a.rating);
-    }
-    return reviews;
-  };
-
   return (
-    <div>
-      <ReviewSortButtons sort={sort} onChange={setSort} />
+    <>
+      {/* 헤더 + 필터 */}
+      <section className="bg-[#F9FAFB] py-16">
+        <div className="max-w-7xl mx-auto px-6 md:px-12 space-y-6">
+          {/* 제목 */}
+          <div className="space-y-1">
+            <h2 className="text-2xl font-bold text-gray-900">여행 리뷰 목록</h2>
+            <p className="text-sm text-gray-500">
+              다른 여행자들의 후기를 읽고, 나만의 여행 이야기도 남겨보세요!
+            </p>
+            <p className="text-xs text-gray-400">
+              총 {reviews?.length || 0}개의 리뷰
+            </p>
+          </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {sortReviews(reviews, sort).map((review) => (
-          <ReviewCard key={review.id} review={review} />
-        ))}
-      </div>
-    </div>
+          {/* 정렬 버튼 + 검색창 */}
+          <div className="flex flex-wrap justify-between items-center gap-4 pt-4">
+            {/* 정렬 필터 */}
+            <div className="flex gap-2">
+              <button
+                onClick={() => setSort("latest")}
+                className={`px-4 py-1.5 rounded-full text-sm border transition ${
+                  sort === "latest"
+                    ? "bg-black text-white"
+                    : "bg-white text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                최신순
+              </button>
+              <button
+                onClick={() => setSort("rating")}
+                className={`px-4 py-1.5 rounded-full text-sm border transition ${
+                  sort === "rating"
+                    ? "bg-black text-white"
+                    : "bg-white text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                별점순
+              </button>
+            </div>
+
+            {/* 검색창 */}
+            <div className="relative w-full max-w-xs">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <input
+                type="text"
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                placeholder="여행지 이름으로 리뷰 검색"
+                className="w-full pl-10 pr-4 py-2 rounded-full border text-sm focus:outline-none focus:ring-1 focus:ring-black"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 리뷰 카드 목록 */}
+      <section className="max-w-7xl mx-auto px-6 md:px-12 py-16">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredReviews.length > 0 ? (
+            filteredReviews.map((review) => (
+              <ReviewCard key={review.id} review={review} />
+            ))
+          ) : (
+            <div className="col-span-full text-center text-gray-500 py-32">
+              <p className="text-lg font-semibold mb-2">리뷰가 없습니다</p>
+              <p className="text-sm">
+                다른 지역을 선택하거나 검색어를 바꿔보세요.
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+    </>
   );
 }

--- a/src/components/review/ReviewList.jsx
+++ b/src/components/review/ReviewList.jsx
@@ -55,7 +55,7 @@ export default function ReviewList() {
           {/* 제목 */}
           <div className="space-y-1">
             <h2 className="text-2xl font-bold text-gray-900">여행 리뷰 목록</h2>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-500 py-1">
               다른 여행자들의 후기를 읽고, 나만의 여행 이야기도 남겨보세요!
             </p>
             <p className="text-xs text-gray-400">
@@ -64,7 +64,7 @@ export default function ReviewList() {
           </div>
 
           {/* 정렬 버튼 + 검색창 */}
-          <div className="flex flex-wrap justify-between items-center gap-4 pt-4">
+          <div className="flex flex-wrap justify-between items-center gap-4">
             {/* 정렬 필터 */}
             <div className="flex gap-2">
               <button

--- a/src/components/review/ReviewList.jsx
+++ b/src/components/review/ReviewList.jsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from "react";
 import { useReviews } from "services/queries/review/useReviews";
 
-import ReviewCard from "./ReviewCard";
+import ReviewCard from "components/review/ReviewCard";
 import LoadingSpinner from "components/common/LoadingSpinner";
 import EmptyState from "components/common/EmptyState";
 import { Search } from "lucide-react";
+import CreateCard from "components/common/CreateCard";
 
 export default function ReviewList() {
   const [sort, setSort] = useState("latest");
@@ -106,6 +107,14 @@ export default function ReviewList() {
       {/* 리뷰 카드 목록 */}
       <section className="max-w-7xl mx-auto px-6 md:px-12 py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {/* 항상 표시되는 리뷰 생성 카드 */}
+          <CreateCard
+            to="/reviews/new"
+            title="여행 후기 작성하기"
+            description="여행의 감동을 나누고, 다음 여행자를 도와주세요"
+            buttonLabel="리뷰 작성하기"
+          />
+
           {filteredReviews.length > 0 ? (
             filteredReviews.map((review) => (
               <ReviewCard key={review.id} review={review} />

--- a/src/pages/review/List.jsx
+++ b/src/pages/review/List.jsx
@@ -1,27 +1,5 @@
 import ReviewList from "components/Review/ReviewList";
-import { Link } from "react-router-dom";
 
 export default function ReviewListPage() {
-  return (
-    <div className="max-w-4xl mx-auto px-4 mt-10">
-      <div className="flex justify-between items-start mb-20">
-        <div>
-          <h2 className="text-2xl font-bold">여행 리뷰 목록</h2>
-          <p className="text-sm text-gray-500 mt-1">
-            다른 여행자들의 후기를 읽고, 나만의 여행 이야기도 남겨보세요!
-          </p>
-        </div>
-
-        <Link
-          to="/reviews/create"
-          className="bg-gray-900 text-white text-sm px-4 py-2 rounded hover:bg-gray-800 transition"
-          aria-label="리뷰 작성 페이지로 이동"
-        >
-          리뷰 작성하기
-        </Link>
-      </div>
-
-      <ReviewList />
-    </div>
-  );
+  return <ReviewList />;
 }


### PR DESCRIPTION
## 주요 변경사항

- 리뷰 목록 페이지 전체 구조 리디자인
- 일정 목록 페이지와 동일한 레이아웃 구조 적용 (헤더, 정렬, 검색 섹션)
- 최신순 / 별점순 정렬 기능 추가
- 여행지명 기준 검색 기능 구현 (`destination` 필드 기준)
- 일정 검색 UI와 동일한 검색창 컴포넌트 구조 및 스타일 적용
- 카드 레이아웃 그리드 구성 (`1~3열 반응형`)
- Empty 상태 메시지 추가 및 시각적 통일

## 리팩터링

- 리뷰 생성 카드(CreateReviewCard) 추가
- 일정 생성 카드(CreateItineraryCard)와 동일한 스타일의 공통 컴포넌트(`CreateCard`)로 분리 및 재사용

## UI 조정

- 제목 및 설명 텍스트 간격(`py-1`) 추가
- 정렬/검색 영역 여백(`pt-4`) 제거로 시각적 밀도 개선
- 전반적인 여백, 색상, 타이포그래피 디자인 호텔 톤에 맞춰 통일
