### PR TITLE
feat: 리뷰 작성 폼 리디자인 및 useAddReview 훅 복구

### DIFF
--- a/src/components/review/ReviewForm.jsx
+++ b/src/components/review/ReviewForm.jsx
@@ -17,7 +17,7 @@ export default function ReviewForm() {
   const navigate = useNavigate();
 
   const { addReview, isLoading } = useAddReview({
-    onError: (err) => setSubmitError(err.message),
+    onErrorCallback: (err) => setSubmitError(err.message),
   });
 
   const handleSubmit = useCallback(
@@ -27,7 +27,7 @@ export default function ReviewForm() {
       if (!title) newErrors.title = "제목을 입력해주세요.";
       if (!destination) newErrors.destination = "여행지명을 입력해주세요.";
       if (rating === 0) newErrors.rating = "별점을 선택해주세요.";
-      if (!content || content.length < 100)
+      if (!content || content.trim().length < 100)
         newErrors.content = "내용을 100자 이상 입력해주세요.";
       if (Object.keys(newErrors).length > 0) return setErrors(newErrors);
 

--- a/src/components/review/ReviewForm.jsx
+++ b/src/components/review/ReviewForm.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import RatingInput from "./RatingInput";
+import ImageUploader from "components/common/ImageUploader";
 import useAddReview from "services/queries/review/useAddReview";
 
 const MAX_CONTENT_LENGTH = 1000;
@@ -11,46 +12,23 @@ export default function ReviewForm() {
   const [content, setContent] = useState("");
   const [rating, setRating] = useState(0);
   const [image, setImage] = useState(null);
-  const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
   const [errors, setErrors] = useState({});
   const [submitError, setSubmitError] = useState(null);
   const navigate = useNavigate();
 
   const { addReview, isLoading } = useAddReview({
-    onError: (err) => {
-      setSubmitError(err.message);
-    },
+    onError: (err) => setSubmitError(err.message),
   });
 
-  useEffect(() => {
-    if (image) {
-      const objectUrl = URL.createObjectURL(image);
-      setImagePreviewUrl(objectUrl);
-      return () => URL.revokeObjectURL(objectUrl);
-    }
-  }, [image]);
-
-  const handleImageChange = useCallback((e) => {
-    const file = e.target.files[0];
-    if (
-      file &&
-      file.size <= 5 * 1024 * 1024 &&
-      file.type.startsWith("image/")
-    ) {
-      setImage(file);
-    } else {
-      alert("5MB 이하 이미지 파일만 업로드 가능합니다.");
-    }
-  }, []);
-
-  const handleReviewFormSubmit = useCallback(
+  const handleSubmit = useCallback(
     (e) => {
       e.preventDefault();
       const newErrors = {};
       if (!title) newErrors.title = "제목을 입력해주세요.";
       if (!destination) newErrors.destination = "여행지명을 입력해주세요.";
       if (rating === 0) newErrors.rating = "별점을 선택해주세요.";
-      if (!content) newErrors.content = "내용을 입력해주세요.";
+      if (!content || content.length < 100)
+        newErrors.content = "내용을 100자 이상 입력해주세요.";
       if (Object.keys(newErrors).length > 0) return setErrors(newErrors);
 
       addReview({ title, destination, content, rating, image });
@@ -59,135 +37,142 @@ export default function ReviewForm() {
   );
 
   return (
-    <form
-      onSubmit={handleReviewFormSubmit}
-      className="bg-white p-8 rounded-2xl shadow-md border max-w-4xl mx-auto"
-    >
-      <h2 className="text-2xl font-bold mb-6">리뷰 작성하기</h2>
-
-      {submitError && (
-        <p className="text-red-700 text-sm mb-4">{submitError}</p>
-      )}
-
-      {/* 제목 */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          제목
-        </label>
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="예: 제주도 혼행 후기"
-          className={`w-full border ${
-            errors.title ? "border-red-500" : "border-gray-300"
-          } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500`}
-        />
-        {errors.title && (
-          <p className="mt-1 text-sm text-red-500">{errors.title}</p>
-        )}
-      </div>
-
-      {/* 여행지명 */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          여행지명
-        </label>
-        <input
-          type="text"
-          value={destination}
-          onChange={(e) => setDestination(e.target.value)}
-          placeholder="예: 제주"
-          className={`w-full border ${
-            errors.destination ? "border-red-500" : "border-gray-300"
-          } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500`}
-        />
-        {errors.destination && (
-          <p className="mt-1 text-sm text-red-500">{errors.destination}</p>
-        )}
-      </div>
-
-      {/* 별점 */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          별점
-        </label>
-        <RatingInput value={rating} onChange={setRating} />
-        {errors.rating && (
-          <p className="mt-1 text-sm text-red-500">{errors.rating}</p>
-        )}
-      </div>
-
-      {/* 내용 */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          내용
-        </label>
-        <textarea
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="여행 후기를 자세히 작성해주세요 :)"
-          rows={6}
-          maxLength={MAX_CONTENT_LENGTH}
-          className={`w-full border ${
-            errors.content ? "border-red-500" : "border-gray-300"
-          } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500`}
-        />
-        {errors.content && (
-          <p className="mt-1 text-sm text-red-500">{errors.content}</p>
-        )}
-        {content && (
-          <p className="mt-1 text-xs text-gray-500 text-right">
-            {content.length}/1000
+    <>
+      <section className="max-w-4xl mx-auto px-4 py-12">
+        {/* 상단 안내 문구 */}
+        <div className="text-center mb-10">
+          <h2 className="text-3xl font-semibold text-gray-900">
+            혼자 떠난 그 순간, 당신의 이야기로 남겨보세요
+          </h2>
+          <p className="text-sm text-gray-600 mt-2">
+            낯선 도시, 익숙하지 않은 거리, 홀로 마주한 풍경과 감정을
+            기록해보세요
           </p>
-        )}
-      </div>
+        </div>
 
-      {/* 이미지 업로드 */}
-      <div className="mb-6">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          이미지 업로드 (선택)
-        </label>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleImageChange}
-          className="text-sm text-gray-600"
-        />
-        {imagePreviewUrl ? (
-          <img
-            src={imagePreviewUrl}
-            alt="미리보기"
-            onError={(e) => {
-              e.target.onerror = null;
-              e.target.src = "/free-icon-no-pictures-3875148.png";
-            }}
-            className="w-32 h-32 object-cover rounded-lg border mt-2"
-          />
-        ) : (
-          <p className="text-sm text-gray-400">
-            이미지를 선택하면 여기에 미리보기가 표시됩니다.
-          </p>
-        )}
-      </div>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6 bg-white p-8 rounded-2xl shadow-lg border border-gray-100"
+        >
+          {/* 제목 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              리뷰 제목
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="예: 제주도 혼행 후기"
+              className={`w-full border ${
+                errors.title ? "border-red-500" : "border-gray-300"
+              } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-black`}
+            />
+            {errors.title && (
+              <p className="text-sm text-red-500 mt-1">{errors.title}</p>
+            )}
+          </div>
 
-      {/* 버튼 */}
-      <div className="flex gap-4 mt-6">
-        <button
-          type="button"
-          onClick={() => navigate("/reviews")}
-          className="w-1/3 bg-gray-200 text-gray-800 font-semibold py-3 rounded-md hover:bg-gray-300 transition"
-        >
-          취소
-        </button>
-        <button
-          type="submit"
-          disabled={isLoading}
-          className="w-2/3 bg-[#0F172A] text-white font-semibold py-3 rounded-md hover:bg-[#1E293B] transition disabled:opacity-50"
-        >
-          {isLoading ? "등록 중..." : "리뷰 등록하기"}
-        </button>
-      </div>
-    </form>
+          {/* 여행지명 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              여행지명
+            </label>
+            <input
+              type="text"
+              value={destination}
+              onChange={(e) => setDestination(e.target.value)}
+              placeholder="예: 제주"
+              className={`w-full border ${
+                errors.destination ? "border-red-500" : "border-gray-300"
+              } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-black`}
+            />
+            {errors.destination && (
+              <p className="text-sm text-red-500 mt-1">{errors.destination}</p>
+            )}
+          </div>
+
+          {/* 별점 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              별점
+            </label>
+            <RatingInput value={rating} onChange={setRating} />
+            {errors.rating && (
+              <p className="text-sm text-red-500 mt-1">{errors.rating}</p>
+            )}
+          </div>
+
+          {/* 내용 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              여행 이야기
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="혼자였기에 더 특별했던 순간, 잊지 못할 풍경, 만난 사람들, 느꼈던 감정들을 자유롭게 기록해보세요."
+              rows={8}
+              maxLength={MAX_CONTENT_LENGTH}
+              className={`w-full border ${
+                errors.content ? "border-red-500" : "border-gray-300"
+              } rounded-md px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-black`}
+            />
+            {errors.content && (
+              <p className="text-sm text-red-500 mt-1">{errors.content}</p>
+            )}
+            <p className="text-xs text-gray-400 text-right mt-1">
+              {content.length}/1000
+            </p>
+          </div>
+
+          {/* 이미지 업로드 */}
+          <ImageUploader imageFile={image} onChange={setImage} />
+
+          {/* 제출 버튼 */}
+          <div className="flex justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={() => navigate("/reviews")}
+              className="px-5 py-2.5 text-sm rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="px-5 py-2.5 text-sm rounded-md bg-black text-white hover:bg-gray-900 transition disabled:opacity-50"
+            >
+              {isLoading ? "등록 중..." : "리뷰 등록"}
+            </button>
+          </div>
+
+          {/* 제출 에러 */}
+          {submitError && (
+            <p className="text-center text-sm text-red-600 mt-2">
+              {submitError}
+            </p>
+          )}
+        </form>
+
+        {/* 리뷰 작성 안내 박스 */}
+        <div className="mt-12 max-w-3xl mx-auto bg-gray-50 text-sm text-gray-600 px-6 py-5 rounded-xl shadow-sm leading-relaxed">
+          <p className="font-semibold text-gray-800 mb-2">리뷰 작성 안내</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              리뷰 등록 후에도 이미지를 추가하거나 내용을 수정할 수 있습니다.
+            </li>
+            <li>
+              여행 일정을 상세히 전달해주세요. 솔직한 감정과 장소 소개가 다른
+              혼행자에게 큰 도움이 됩니다.
+            </li>
+            <li>
+              작성된 리뷰는 개인 마이페이지 또는 리뷰 리스트에서 확인할 수
+              있습니다.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </>
   );
 }

--- a/src/components/review/ReviewList.jsx
+++ b/src/components/review/ReviewList.jsx
@@ -109,7 +109,7 @@ export default function ReviewList() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {/* 항상 표시되는 리뷰 생성 카드 */}
           <CreateCard
-            to="/reviews/new"
+            to="/reviews/create"
             title="여행 후기 작성하기"
             description="여행의 감동을 나누고, 다음 여행자를 도와주세요"
             buttonLabel="리뷰 작성하기"

--- a/src/pages/review/Create.jsx
+++ b/src/pages/review/Create.jsx
@@ -1,9 +1,5 @@
 import ReviewForm from "components/review/ReviewForm";
 
 export default function CreateReviewPage() {
-  return (
-    <div className="min-h-screen bg-gray-100 py-12 px-4">
-      <ReviewForm />
-    </div>
-  );
+  return <ReviewForm />;
 }

--- a/src/services/queries/review/useAddReview.js
+++ b/src/services/queries/review/useAddReview.js
@@ -13,13 +13,13 @@ import { db } from "services/firebase";
 import { uploadImage } from "utils/uploadImage";
 
 /**
- * 일정 추가 기능을 제공하는 커스텀 훅
+ * 리뷰 추가 기능을 제공하는 커스텀 훅
  * @param {Object} options - 훅 옵션
  * @param {Function} options.onSuccessCallback - 성공 시 콜백
  * @param {Function} options.onErrorCallback - 실패 시 콜백
- * @returns {Object} 일정 추가 관련 함수와 상태
+ * @returns {Object} 리뷰 추가 관련 함수와 상태
  */
-export default function useAddItinerary({
+export default function useAddReview({
   onSuccessCallback = () => {},
   onErrorCallback = () => {},
 } = {}) {
@@ -29,46 +29,41 @@ export default function useAddItinerary({
 
   const checkAuth = () => {
     if (!user) {
-      navigate("/login", { state: { from: "/itinerary/create" } });
+      navigate("/login", { state: { from: "/reviews/create" } });
       throw new Error("로그인이 필요한 서비스입니다.");
     }
   };
 
   const {
-    mutate: addItinerary,
+    mutate: addReview,
     isLoading,
     isError,
     error,
   } = useMutation({
-    mutationFn: async ({
-      title,
-      destination,
-      description,
-      image,
-      isPublic = true,
-      oneLineIntro = "",
-    }) => {
+    mutationFn: async ({ title, destination, content, rating, image }) => {
       checkAuth();
+
       if (!title?.trim()) throw new Error("제목을 입력해주세요.");
-      if (!destination?.trim()) throw new Error("여행지를 입력해주세요.");
+      if (!destination?.trim()) throw new Error("여행지명을 입력해주세요.");
+      if (!content?.trim()) throw new Error("내용을 입력해주세요.");
+      if (!rating) throw new Error("별점을 입력해주세요.");
 
       let imageUrl = "";
 
       if (image) {
         try {
-          imageUrl = await uploadImage(image, "itineraries");
+          imageUrl = await uploadImage(image, "reviews", user.uid);
         } catch (err) {
           throw new Error(err.message);
         }
       }
 
-      await addDoc(collection(db, "itineraries"), {
+      await addDoc(collection(db, "reviews"), {
         title,
         destination,
-        description,
+        content,
+        rating,
         imageUrl,
-        isPublic,
-        oneLineIntro,
         createdBy: {
           uid: user.uid,
           displayName: user.displayName || "익명",
@@ -76,27 +71,28 @@ export default function useAddItinerary({
         },
         createdAt: serverTimestamp(),
         likeCount: 0,
+        commentCount: 0,
       });
 
       await updateDoc(doc(db, "users", user.uid), {
-        itineraryCount: increment(1),
+        reviewCount: increment(1),
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["itineraries"] });
-      alert("일정이 성공적으로 등록되었습니다!");
-      navigate("/itinerary");
+      queryClient.invalidateQueries({ queryKey: ["reviews"] });
+      alert("리뷰가 성공적으로 등록되었습니다!");
+      navigate("/reviews");
       onSuccessCallback();
     },
     onError: (error) => {
       console.error(error);
-      alert(`일정 등록 중 오류가 발생했습니다: ${error.message}`);
+      alert(`리뷰 등록 중 오류가 발생했습니다: ${error.message}`);
       onErrorCallback(error);
     },
   });
 
   return {
-    addItinerary,
+    addReview,
     isLoading,
     isError,
     error,


### PR DESCRIPTION
## 주요 변경 사항

- 리뷰 작성 카드 경로 수정 (`/reviews/new` → `/reviews/create`)
- 리뷰 작성 폼 전체 리디자인 적용
  - 상단 안내 문구 및 입력 UI 개선
  - 이미지 업로드 영역 `ImageUploader` 공통 컴포넌트로 대체
  - 내용 입력 유효성 검증 (100자 이상, trim 포함)

- `useAddReview` 커스텀 훅 재구현
  - 기존에 실수로 삭제된 파일 복구 및 구조 개선
  - `useAddItinerary` 훅 구조를 기반으로 재작성
  - Firebase Firestore에 리뷰 등록
  - 이미지 업로드, 작성자 정보 저장, 사용자 리뷰 수 증가 처리 포함
  - 등록 성공 시 `/reviews`로 이동 + `reviews` 쿼리 invalidate
  
- mutate 호출 방식 오류 수정
  - 기존 `addReview is not a function` 에러 해결