### PR TITLE
feat: 리뷰 상세 페이지 전체 UI 리디자인 및 감성 개선

### DIFF
--- a/src/components/common/FloatingButtons.jsx
+++ b/src/components/common/FloatingButtons.jsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useDeleteItinerary } from "services/queries/itinerary/useDeleteItinerary";
 
@@ -39,12 +39,34 @@ export function DeleteFloatingButton() {
   );
 }
 
-// 두 버튼을 묶어주는 Wrapper
+export function BackFloatingButton() {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      onClick={() => navigate(-1)}
+      className="bg-white text-gray-700 p-3 rounded-full shadow-lg hover:bg-gray-100 transition border border-gray-300"
+      aria-label="이전 페이지로 돌아가기"
+    >
+      <ArrowLeft className="w-4 h-4" />
+    </button>
+  );
+}
+
+// 버튼을 묶어주는 Wrapper
 export default function FloatingButtons() {
   return (
-    <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">
-      <EditFloatingButton />
-      <DeleteFloatingButton />
-    </div>
+    <>
+      {/* 왼쪽 하단: 돌아가기 */}
+      <div className="fixed bottom-6 left-6 z-50">
+        <BackFloatingButton />
+      </div>
+
+      {/* 오른쪽 하단: 수정/삭제 */}
+      <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">
+        <EditFloatingButton />
+        <DeleteFloatingButton />
+      </div>
+    </>
   );
 }

--- a/src/components/review/CommentItem.jsx
+++ b/src/components/review/CommentItem.jsx
@@ -1,5 +1,8 @@
 import { useDeleteComment } from "services/queries/review/useDeleteComment";
 
+import { Trash2 } from "lucide-react";
+import { cn } from "utils/utils";
+
 export default function CommentItem({ comment, currentUserId, reviewId }) {
   const { id, content, createdAt, authorId, authorName } = comment;
   const isAuthor = currentUserId === authorId;
@@ -11,23 +14,39 @@ export default function CommentItem({ comment, currentUserId, reviewId }) {
   };
 
   return (
-    <div className="border p-4 rounded">
-      <div className="text-sm text-gray-600 mb-1">
-        <span className="font-semibold">{authorName}</span> ·{" "}
-        <span>
+    <div className="relative bg-white/70 backdrop-blur-sm border border-gray-200 rounded-xl p-5 shadow-sm">
+      {/* 작성자 & 시간 */}
+      <div className="flex items-center gap-3 mb-2 text-sm text-gray-600">
+        <img
+          src={comment.authorPhotoURL || "/default_profile.png"}
+          alt="작성자 프로필"
+          className="w-6 h-6 rounded-full object-cover"
+        />
+        <span className="font-semibold text-gray-800">{authorName}</span>
+        <span className="text-gray-400 text-xs">
           {createdAt?.toDate?.()
             ? new Date(createdAt.toDate()).toLocaleString()
             : "날짜 없음"}
         </span>
       </div>
-      <p className="text-gray-800">{content}</p>
+
+      {/* 내용 */}
+      <p className="text-sm text-gray-800 leading-relaxed whitespace-pre-line">
+        {content}
+      </p>
+
+      {/* 삭제 버튼 */}
       {isAuthor && (
         <button
           onClick={handleCommentDelete}
           disabled={isPending}
-          className="text-sm text-red-500 mt-2 hover:underline"
+          aria-label="댓글 삭제"
+          className={cn(
+            "absolute top-3 right-3 text-gray-400 hover:text-red-500 transition",
+            isPending && "opacity-50 cursor-not-allowed"
+          )}
         >
-          {isPending ? "삭제 중..." : "삭제"}
+          <Trash2 className="w-4 h-4" />
         </button>
       )}
     </div>

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -1,15 +1,14 @@
-// components/review/CommentList.jsx
 import { useState } from "react";
 import { useComments } from "services/queries/review/useComments";
 import CommentItem from "components/review/CommentItem";
 import { useUser } from "hooks/useUser";
 import { useAddComment } from "services/queries/review/useAddComment";
+import { Send } from "lucide-react";
 
 export default function CommentList({ currentUserId, reviewId }) {
   const [content, setContent] = useState("");
   const { user } = useUser();
   const { data: comments, isLoading } = useComments(reviewId);
-
   const { mutate, isPending } = useAddComment(reviewId);
 
   const handleCommentSubmit = (e) => {
@@ -26,41 +25,89 @@ export default function CommentList({ currentUserId, reviewId }) {
   };
 
   return (
-    <div className="mt-8 space-y-4">
-      {/* 댓글 작성 폼 */}
-      <form onSubmit={handleCommentSubmit} className="flex flex-col gap-2">
-        <textarea
-          className="border p-2 rounded resize-none"
-          rows={3}
-          placeholder="댓글을 입력하세요"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          disabled={isPending}
-        />
-        <button
-          type="submit"
-          disabled={isPending || !content.trim()}
-          className="self-end bg-black text-white px-4 py-2 rounded disabled:opacity-50"
-        >
-          {isPending ? "작성 중..." : "댓글 작성"}
-        </button>
-      </form>
+    <div className="bg-white rounded-2xl shadow-sm px-6 py-8 space-y-8">
+      {/* 댓글 입력 박스 */}
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 mb-4">
+          이 여행지에서의 감정을 나눠보세요
+        </h3>
+
+        <form onSubmit={handleCommentSubmit} className="space-y-2">
+          <div className="flex items-start gap-3">
+            <img
+              src={user?.photoURL || "/default_profile.png"}
+              alt="프로필"
+              className="w-10 h-10 rounded-full object-cover"
+            />
+            <textarea
+              rows={3}
+              className="w-full resize-none border border-gray-300 rounded-md p-3 text-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-black"
+              placeholder="이 여행지에서의 당신의 감정을 들려주세요..."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+          <div className="flex justify-between items-center">
+            <p className="text-xs text-gray-400">
+              타인을 존중하는 따뜻한 댓글을 남겨주세요. 비방이나 무례한 표현은
+              제재될 수 있어요.
+            </p>
+            <button
+              type="submit"
+              disabled={isPending || !content.trim()}
+              className="text-sm px-4 py-1.5 rounded-full bg-gray-900 text-white hover:bg-gray-800 transition disabled:opacity-50"
+            >
+              {isPending ? "등록 중..." : "등록"}
+            </button>
+          </div>
+        </form>
+      </div>
 
       {/* 댓글 목록 */}
-      <div className="space-y-4">
+      <div>
+        <h4 className="text-sm text-gray-500 font-medium mb-4">
+          여행자들의 감성 코멘트{" "}
+          <span className="ml-1 text-gray-400 font-normal">
+            ({comments?.length || 0})
+          </span>
+        </h4>
+
         {isLoading ? (
           <p className="text-gray-500 text-sm">댓글을 불러오는 중...</p>
         ) : comments?.length > 0 ? (
-          comments.map((comment) => (
-            <CommentItem
-              key={comment.id}
-              comment={comment}
-              currentUserId={currentUserId}
-              reviewId={reviewId}
-            />
-          ))
+          <div className="space-y-4">
+            {comments.map((comment) => (
+              <CommentItem
+                key={comment.id}
+                comment={comment}
+                currentUserId={currentUserId}
+                reviewId={reviewId}
+              />
+            ))}
+          </div>
         ) : (
-          <p className="text-gray-400 text-sm">첫 댓글을 남겨보세요.</p>
+          <div className="text-center text-gray-400 py-12">
+            <div className="flex justify-center mb-4">
+              <Send className="w-10 h-10 opacity-30" />
+            </div>
+            <p className="font-semibold text-sm mb-1">
+              아직 남겨진 이야기가 없어요
+            </p>
+            <p className="text-sm mb-4 text-gray-500">
+              이 여행지에서의 <strong>특별한 순간</strong>을 나눠주세요.
+              <br />
+              당신의 이야기가 다른 혼행자들의 공감이 될 수 있어요.
+            </p>
+            <button
+              onClick={() =>
+                document.getElementById("comment-textarea")?.focus()
+              }
+              className="px-4 py-2 text-sm bg-black text-white rounded-full hover:bg-gray-900 transition"
+            >
+              첫 번째 코멘트 남기기
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/review/LikeButton.jsx
+++ b/src/components/review/LikeButton.jsx
@@ -5,21 +5,20 @@ import {
   useToggleReviewLike,
 } from "services/queries/review/useReviewLike";
 import { cn } from "utils/utils";
-import { useReviewDetail } from "services/queries/review/useReviewDetail";
 
-export default function LikeButton({ reviewId }) {
+export default function LikeButton({
+  reviewId,
+  likesCount = 0,
+  variant = "card",
+}) {
   const { user } = useUser();
   const userId = user?.uid;
 
-  const { data: hasLiked, isLoading: isChecking } = useReviewLikeStatus(
-    reviewId,
-    userId
-  );
+  const { data: hasLiked } = useReviewLikeStatus(reviewId, userId);
   const { mutate, isPending: isMutating } = useToggleReviewLike(
     reviewId,
     userId
   );
-  const { data: review } = useReviewDetail(reviewId);
 
   const handleLikeBtnClick = (e) => {
     e.stopPropagation();
@@ -27,25 +26,35 @@ export default function LikeButton({ reviewId }) {
     mutate();
   };
 
+  const baseClass = "flex items-center gap-1 transition-all";
+  const disabledClass = isMutating ? "opacity-50 cursor-not-allowed" : "";
+  const variantClass =
+    variant === "detail"
+      ? "px-3 py-1.5 rounded-full border border-gray-300 text-sm bg-white/60 text-gray-800 backdrop-blur-sm shadow-sm hover:bg-white/80 transition"
+      : "text-sm text-gray-500 hover:text-red-500 transition";
   return (
     <button
       onClick={handleLikeBtnClick}
       disabled={!user || isMutating}
-      className={cn(
-        "flex items-center gap-1 transition-all",
-        isMutating && "opacity-50 cursor-not-allowed"
-      )}
+      className={cn(baseClass, disabledClass, variantClass)}
       aria-label={hasLiked ? "좋아요 취소" : "좋아요 누르기"}
     >
       {hasLiked ? (
-        <AiFillHeart className="text-red-500" size={18} />
+        <AiFillHeart
+          className={
+            variant === "detail" ? "text-red-500 w-4 h-4" : "text-red-500"
+          }
+        />
       ) : (
         <AiOutlineHeart
-          className="text-gray-400 hover:text-red-500"
-          size={18}
+          className={
+            variant === "detail"
+              ? "text-gray-400 hover:text-red-500 w-4 h-4"
+              : "text-gray-400 hover:text-red-500"
+          }
         />
       )}
-      <span className="text-sm text-gray-600">{review?.likesCount ?? 0}</span>
+      <span className="font-medium">{likesCount}</span>
     </button>
   );
 }

--- a/src/components/review/ReportButton.jsx
+++ b/src/components/review/ReportButton.jsx
@@ -27,7 +27,7 @@ export default function ReportButton({ reviewId }) {
       <button
         onClick={handleOpen}
         disabled={reportMutation.isPending}
-        className="text-sm text-red-500 hover:underline disabled:opacity-50"
+        className="px-3 py-1.5 rounded-full border border-gray-300 text-sm bg-white/60 text-gray-800 backdrop-blur-sm shadow-sm hover:bg-white/80 transition disabled:opacity-50"
       >
         {reportMutation.isPending ? "신고 중..." : "신고하기"}
       </button>

--- a/src/components/review/ReviewCard.jsx
+++ b/src/components/review/ReviewCard.jsx
@@ -114,7 +114,7 @@ export default function ReviewCard({ review }) {
               }}
             />
           </div>
-          <LikeButton reviewId={id} />
+          <LikeButton reviewId={review.id} likesCount={review.likesCount} />
         </div>
       </div>
     </div>

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -44,9 +44,32 @@ export default function ReviewDetail({ reviewId }) {
         </div>
 
         {/* 댓글 */}
-        <section className="max-w-4xl mx-auto px-4 mt-12">
-          <h2 className="text-xl font-semibold mb-4">댓글</h2>
-          <CommentList currentUserId={user?.uid} reviewId={reviewId} />
+        <section className="max-w-6xl mx-auto px-4 mt-16 flex flex-col md:flex-row gap-8">
+          {/* 댓글 작성 & 리스트 - 왼쪽 영역 */}
+          <div className="md:w-2/3">
+            <h2 className="text-xl font-bold text-gray-900 mb-2">
+              혼행자의 감상 한 줄
+            </h2>
+            <p className="text-sm text-gray-500 mb-6">
+              같은 장소, 다른 감정. 다른 여행자의 시선을 통해 더 깊이
+              바라보세요.
+            </p>
+            <CommentList currentUserId={user?.uid} reviewId={reviewId} />
+          </div>
+
+          {/* 유의사항 카드 - 오른쪽 영역 */}
+          <aside className="md:w-1/3">
+            <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 text-sm leading-relaxed text-gray-600 shadow-sm">
+              <p className="font-semibold text-gray-800 mb-2">
+                댓글 작성 시 유의사항
+              </p>
+              <ul className="list-disc list-inside space-y-1">
+                <li>비방, 욕설, 혐오 표현은 삭제될 수 있어요.</li>
+                <li>개인 정보는 입력하지 말아주세요.</li>
+                <li>여기 남긴 감정이 또 다른 여행의 시작이 됩니다.</li>
+              </ul>
+            </div>
+          </aside>
         </section>
       </div>
     </article>

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import { useReviewDetail } from "services/queries/review/useReviewDetail";
 import LoadingSpinner from "components/common/LoadingSpinner";
 import NotFoundMessage from "components/common/NotFoundMessage";
@@ -6,11 +5,10 @@ import ReportButton from "components/Review/ReportButton";
 import LikeButton from "components/review/LikeButton";
 import CommentList from "components/review/CommentList";
 import { useUser } from "hooks/useUser";
-import ReviewHero from "components/review/ReviewHero"; // 추가된 Hero 컴포넌트
+import ReviewHero from "components/review/ReviewHero";
 
 export default function ReviewDetail({ reviewId }) {
   const { user } = useUser();
-  const navigate = useNavigate();
   const { data, isLoading, isError } = useReviewDetail(reviewId);
 
   if (isLoading) return <LoadingSpinner />;
@@ -24,20 +22,29 @@ export default function ReviewDetail({ reviewId }) {
       {/* Hero 섹션 */}
       <ReviewHero review={data} />
 
-      <div className="max-w-3xl mx-auto px-4 mt-12">
+      <div className="px-4 mt-12">
         {/* 본문 내용 */}
-        <div className="text-gray-800 leading-relaxed mb-8 whitespace-pre-line">
-          {content || "리뷰 내용이 없습니다."}
+        <div className="relative pl-6 border-l-2 border-dashed border-gray-300 text-gray-800 bg-[#F4F4F5]/50 p-6 rounded-xl">
+          <p className="text-sm text-gray-500 mb-2">기억하고 싶은 순간</p>
+          <div className="text-[16px] leading-relaxed tracking-wide whitespace-pre-line">
+            {content || "리뷰 내용이 없습니다."}
+          </div>
         </div>
 
         {/* 좋아요 / 신고 */}
-        <div className="flex justify-end items-center gap-4">
-          <LikeButton reviewId={reviewId} likesCount={likesCount} />
-          <ReportButton reviewId={reviewId} />
+        <div className="flex justify-end items-center mt-10 text-sm text-gray-400">
+          <div className="flex gap-4 items-center text-gray-500">
+            <LikeButton
+              reviewId={reviewId}
+              likesCount={likesCount}
+              variant="detail"
+            />
+            <ReportButton reviewId={reviewId} />
+          </div>
         </div>
 
         {/* 댓글 */}
-        <section className="mt-12">
+        <section className="max-w-4xl mx-auto px-4 mt-12">
           <h2 className="text-xl font-semibold mb-4">댓글</h2>
           <CommentList currentUserId={user?.uid} reviewId={reviewId} />
         </section>

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -1,0 +1,85 @@
+import { useNavigate } from "react-router-dom";
+import { useReviewDetail } from "services/queries/review/useReviewDetail";
+import LoadingSpinner from "components/common/LoadingSpinner";
+import NotFoundMessage from "components/common/NotFoundMessage";
+import ReportButton from "components/Review/ReportButton";
+import LikeButton from "components/review/LikeButton";
+import CommentList from "components/review/CommentList";
+import { formatDate } from "utils/formatDate";
+import { useUser } from "hooks/useUser";
+
+export default function ReviewDetail({ reviewId }) {
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useReviewDetail(reviewId);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (isError || !data)
+    return <NotFoundMessage message="리뷰를 찾을 수 없습니다." />;
+
+  const {
+    title,
+    destination,
+    content,
+    rating,
+    authorName,
+    createdAt,
+    imageUrl,
+    likesCount,
+  } = data;
+
+  return (
+    <article className="max-w-3xl mx-auto py-10 px-4 bg-white rounded-lg shadow-sm">
+      <header>
+        <button
+          onClick={() => navigate("/reviews")}
+          className="text-sm text-gray-500 mb-2 hover:underline"
+          aria-label="리뷰 목록으로 돌아가기"
+        >
+          ← 목록으로 돌아가기
+        </button>
+
+        <h1 className="text-2xl font-bold mb-2">{title}</h1>
+        <p className="text-gray-500 text-sm mb-4">
+          {destination} · ⭐ {rating} · {authorName}
+        </p>
+        <p className="text-gray-400 text-xs mb-6">{formatDate(createdAt)}</p>
+      </header>
+
+      {/* 이미지 */}
+      <div className="mb-6">
+        <img
+          src={imageUrl || "/images/no_image.png"}
+          alt="리뷰 이미지"
+          onError={(e) => {
+            if (e.target.src.includes("no_image.png")) return;
+            e.target.onerror = null;
+            e.target.src = "/images/no_image.png";
+          }}
+          className={`w-full rounded-lg bg-gray-100 ${
+            imageUrl
+              ? "object-cover aspect-[4/3]"
+              : "object-contain max-h-[400px]"
+          }`}
+        />
+      </div>
+
+      {/* 본문 */}
+      <div className="text-gray-800 leading-relaxed mb-6 whitespace-pre-line">
+        {content || "리뷰 내용이 없습니다."}
+      </div>
+
+      {/* 좋아요/신고 */}
+      <div className="flex justify-end items-center gap-4 mt-8">
+        <LikeButton reviewId={reviewId} likesCount={likesCount} />
+        <ReportButton reviewId={reviewId} />
+      </div>
+
+      {/* 댓글 */}
+      <section className="mt-10">
+        <h2 className="text-xl font-semibold mb-4">댓글</h2>
+        <CommentList currentUserId={user?.uid} reviewId={reviewId} />
+      </section>
+    </article>
+  );
+}

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -25,14 +25,6 @@ export default function ReviewDetail({ reviewId }) {
       <ReviewHero review={data} />
 
       <div className="max-w-3xl mx-auto px-4 mt-12">
-        {/* 돌아가기 버튼 */}
-        <button
-          onClick={() => navigate("/reviews")}
-          className="text-sm text-gray-500 mb-6 hover:underline"
-        >
-          ← 목록으로 돌아가기
-        </button>
-
         {/* 본문 내용 */}
         <div className="text-gray-800 leading-relaxed mb-8 whitespace-pre-line">
           {content || "리뷰 내용이 없습니다."}

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -43,6 +43,9 @@ export default function ReviewDetail({ reviewId }) {
           </div>
         </div>
 
+        {/* 구분선 */}
+        <div className="my-12 border-t border-gray-200" />
+
         {/* 댓글 */}
         <section className="max-w-6xl mx-auto px-4 mt-16 flex flex-col md:flex-row gap-8">
           {/* 댓글 작성 & 리스트 - 왼쪽 영역 */}

--- a/src/components/review/ReviewDetail.jsx
+++ b/src/components/review/ReviewDetail.jsx
@@ -5,8 +5,8 @@ import NotFoundMessage from "components/common/NotFoundMessage";
 import ReportButton from "components/Review/ReportButton";
 import LikeButton from "components/review/LikeButton";
 import CommentList from "components/review/CommentList";
-import { formatDate } from "utils/formatDate";
 import { useUser } from "hooks/useUser";
+import ReviewHero from "components/review/ReviewHero"; // 추가된 Hero 컴포넌트
 
 export default function ReviewDetail({ reviewId }) {
   const { user } = useUser();
@@ -17,69 +17,39 @@ export default function ReviewDetail({ reviewId }) {
   if (isError || !data)
     return <NotFoundMessage message="리뷰를 찾을 수 없습니다." />;
 
-  const {
-    title,
-    destination,
-    content,
-    rating,
-    authorName,
-    createdAt,
-    imageUrl,
-    likesCount,
-  } = data;
+  const { content, likesCount } = data;
 
   return (
-    <article className="max-w-3xl mx-auto py-10 px-4 bg-white rounded-lg shadow-sm">
-      <header>
+    <article className="pb-16">
+      {/* Hero 섹션 */}
+      <ReviewHero review={data} />
+
+      <div className="max-w-3xl mx-auto px-4 mt-12">
+        {/* 돌아가기 버튼 */}
         <button
           onClick={() => navigate("/reviews")}
-          className="text-sm text-gray-500 mb-2 hover:underline"
-          aria-label="리뷰 목록으로 돌아가기"
+          className="text-sm text-gray-500 mb-6 hover:underline"
         >
           ← 목록으로 돌아가기
         </button>
 
-        <h1 className="text-2xl font-bold mb-2">{title}</h1>
-        <p className="text-gray-500 text-sm mb-4">
-          {destination} · ⭐ {rating} · {authorName}
-        </p>
-        <p className="text-gray-400 text-xs mb-6">{formatDate(createdAt)}</p>
-      </header>
+        {/* 본문 내용 */}
+        <div className="text-gray-800 leading-relaxed mb-8 whitespace-pre-line">
+          {content || "리뷰 내용이 없습니다."}
+        </div>
 
-      {/* 이미지 */}
-      <div className="mb-6">
-        <img
-          src={imageUrl || "/images/no_image.png"}
-          alt="리뷰 이미지"
-          onError={(e) => {
-            if (e.target.src.includes("no_image.png")) return;
-            e.target.onerror = null;
-            e.target.src = "/images/no_image.png";
-          }}
-          className={`w-full rounded-lg bg-gray-100 ${
-            imageUrl
-              ? "object-cover aspect-[4/3]"
-              : "object-contain max-h-[400px]"
-          }`}
-        />
+        {/* 좋아요 / 신고 */}
+        <div className="flex justify-end items-center gap-4">
+          <LikeButton reviewId={reviewId} likesCount={likesCount} />
+          <ReportButton reviewId={reviewId} />
+        </div>
+
+        {/* 댓글 */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold mb-4">댓글</h2>
+          <CommentList currentUserId={user?.uid} reviewId={reviewId} />
+        </section>
       </div>
-
-      {/* 본문 */}
-      <div className="text-gray-800 leading-relaxed mb-6 whitespace-pre-line">
-        {content || "리뷰 내용이 없습니다."}
-      </div>
-
-      {/* 좋아요/신고 */}
-      <div className="flex justify-end items-center gap-4 mt-8">
-        <LikeButton reviewId={reviewId} likesCount={likesCount} />
-        <ReportButton reviewId={reviewId} />
-      </div>
-
-      {/* 댓글 */}
-      <section className="mt-10">
-        <h2 className="text-xl font-semibold mb-4">댓글</h2>
-        <CommentList currentUserId={user?.uid} reviewId={reviewId} />
-      </section>
     </article>
   );
 }

--- a/src/components/review/ReviewHero.jsx
+++ b/src/components/review/ReviewHero.jsx
@@ -26,7 +26,7 @@ export default function ReviewHero({ review }) {
       />
       <div className="absolute inset-0 bg-black/50" />
 
-      <div className="relative z-10 max-w-4xl mx-auto px-6 h-full flex flex-col justify-end pb-9 text-white">
+      <div className="relative z-10 max-w-6xl mx-auto px-6 h-full flex flex-col justify-end pb-9 text-white">
         {/* 제목 */}
         <h1 className="text-3xl font-bold">{title}</h1>
 

--- a/src/components/review/ReviewHero.jsx
+++ b/src/components/review/ReviewHero.jsx
@@ -1,0 +1,58 @@
+import { formatDate } from "utils/formatDate";
+import { Star, MapPin } from "lucide-react";
+
+export default function ReviewHero({ review }) {
+  const {
+    title,
+    destination,
+    rating,
+    authorName,
+    authorPhotoURL,
+    createdAt,
+    imageUrl,
+  } = review || {};
+
+  return (
+    <div className="relative h-[420px] w-full rounded-3xl overflow-hidden">
+      <img
+        src={imageUrl || "/images/no_image.png"}
+        alt={title}
+        className="absolute inset-0 w-full h-full object-cover bg-gray-100"
+        onError={(e) => {
+          if (e.target.src.includes("no_image.png")) return;
+          e.target.onerror = null;
+          e.target.src = "/images/no_image.png";
+        }}
+      />
+      <div className="absolute inset-0 bg-black/50" />
+
+      <div className="relative z-10 max-w-4xl mx-auto px-6 h-full flex flex-col justify-end pb-9 text-white">
+        {/* 제목 */}
+        <h1 className="text-3xl font-bold">{title}</h1>
+
+        {/* 여행지 + 별점 */}
+        <div className="flex items-center gap-4 text-sm opacity-90 my-2">
+          <div className="flex items-center gap-1">
+            <MapPin className="w-4 h-4" />
+            <span>{destination}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Star className="w-4 h-4 text-yellow-300" />
+            <span>{rating}</span>
+          </div>
+        </div>
+
+        {/* 작성자 + 날짜 */}
+        <div className="flex items-center gap-3 mt-4 text-sm text-white/70">
+          <img
+            src={authorPhotoURL || "/default_profile.png"}
+            alt="작성자"
+            className="w-6 h-6 rounded-full object-cover"
+          />
+          <span>{authorName || "익명"}</span>
+          <span className="text-xs">· {formatDate(createdAt)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/review/Detail.jsx
+++ b/src/pages/review/Detail.jsx
@@ -1,90 +1,13 @@
-import { useParams, useNavigate } from "react-router-dom";
-import { useReviewDetail } from "services/queries/review/useReviewDetail";
-import LoadingSpinner from "components/common/LoadingSpinner";
-import NotFoundMessage from "components/common/NotFoundMessage";
-import ReportButton from "components/Review/ReportButton";
-
-import { formatDate } from "utils/formatDate";
-import { useUser } from "hooks/useUser";
-
-import LikeButton from "components/review/LikeButton";
-import CommentList from "components/review/CommentList";
+import { useParams } from "react-router-dom";
+import ReviewDetail from "components/review/ReviewDetail";
+import LayoutWrapper from "components/common/LayoutWrapper";
 
 export default function ReviewDetailPage() {
   const { id } = useParams();
-  const { user } = useUser();
-  const { data, isLoading, isError } = useReviewDetail(id);
-
-  const navigate = useNavigate();
-
-  if (isLoading) return <LoadingSpinner />;
-  if (isError || !data)
-    return <NotFoundMessage message="리뷰를 찾을 수 없습니다." />;
-
-  const {
-    title,
-    destination,
-    content,
-    rating,
-    authorName,
-    createdAt,
-    imageUrl,
-    likesCount,
-  } = data;
 
   return (
-    <article className="max-w-3xl mx-auto py-10 px-4 bg-white rounded-lg shadow-sm">
-      <header>
-        <div className="mb-2">
-          <button
-            onClick={() => navigate("/reviews")}
-            className="text-sm text-gray-500 mb-2 hover:underline"
-            aria-label="리뷰 목록으로 돌아가기"
-          >
-            ← 목록으로 돌아가기
-          </button>
-        </div>
-        <h1 className="text-2xl font-bold mb-2">{title}</h1>
-        <p className="text-gray-500 text-sm mb-4">
-          {destination} ·{" "}
-          <span aria-label={`평점 ${rating}점`}>⭐ {rating}</span> ·{" "}
-          {authorName}
-        </p>
-        <p className="text-gray-400 text-xs mb-6">{formatDate(createdAt)}</p>
-      </header>
-
-      <div className="mb-6">
-        <img
-          src={imageUrl || "/images/no_image.png"}
-          alt="리뷰 이미지"
-          onError={(e) => {
-            // 무한 반복 방지
-            if (e.target.src.includes("no_image.png")) return;
-            e.target.onerror = null;
-            e.target.src = "/images/no_image.png";
-          }}
-          className={`w-full rounded-lg bg-gray-100 ${
-            imageUrl
-              ? "object-cover aspect-[4/3]"
-              : "object-contain max-h-[400px]"
-          }`}
-        />
-      </div>
-
-      <div className="text-gray-800 leading-relaxed mb-6 whitespace-pre-line">
-        {content || "리뷰 내용이 없습니다."}
-      </div>
-
-      <div className="flex justify-end items-center gap-4 mt-8">
-        <LikeButton reviewId={id} likesCount={likesCount} />
-        <ReportButton reviewId={id} />
-      </div>
-
-      {/* 댓글 섹션 */}
-      <section className="mt-10">
-        <h2 className="text-xl font-semibold mb-4">댓글</h2>
-        <CommentList currentUserId={user?.uid} reviewId={id} />
-      </section>
-    </article>
+    <LayoutWrapper>
+      <ReviewDetail reviewId={id} />
+    </LayoutWrapper>
   );
 }

--- a/src/services/queries/review/useAddReview.js
+++ b/src/services/queries/review/useAddReview.js
@@ -69,6 +69,8 @@ export default function useAddReview({
           displayName: user.displayName || "익명",
           photoURL: user.photoURL || "",
         },
+        authorName: user.displayName || "익명",
+        authorPhotoURL: user.photoURL || "",
         createdAt: serverTimestamp(),
         likeCount: 0,
         commentCount: 0,


### PR DESCRIPTION
### 주요 작업 내용
- 리뷰 상세 페이지 구조 분리 및 레이아웃 통일
  - ReviewDetailPage → ReviewDetail로 컴포넌트 분리
  - LayoutWrapper 적용으로 전체 레이아웃 일관성 확보
- 리뷰 상단 Hero 섹션 컴포넌트(ReviewHero)로 분리
  - 일정 상세 페이지 Hero와 정렬 구조 통일
  - 여행지명, 별점, 작성자 정보, 작성일 등 정렬 및 스타일 개선
- 본문 영역 감성 강화
  - border-l-dashed + 배경 박스 스타일 적용
  - 타이틀 문구 “기억하고 싶은 순간” 추가
- 좋아요/신고 버튼 스타일 개선
  - variant props로 카드/상세 디자인 분기 처리
  - BackFloatingButton 추가로 뒤로가기 버튼 통일
- 댓글 섹션 전면 리디자인
  - 감성적 타이틀/서브 문구 추가
  - 2단 레이아웃 구성 (왼쪽: 댓글, 오른쪽: 안내/유의사항)
  - 댓글 리스트 아이템 디자인 개선: 프로필, 이름, 시간, 삭제 버튼
  - 댓글 없을 때의 Empty 뷰 감성 메시지 및 아이콘 교체
- Hero ~ 댓글까지 전체 흐름 시각적 통일성 강화
  - 좋아요/신고 영역과 댓글 영역 사이 구분선 추가

### 기타 수정 사항
- 리뷰 등록 시 작성자 정보 누락 오류 수정 (authorName, authorPhotoURL 추가)
- 리뷰 목록 → 상세 → 댓글까지 스타일 일관성 유지
