### PR TITLE
refactor: Firestore 구조 개선 및 작성자 정보 통일

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,10 +27,10 @@ service cloud.firestore {
     match /reviews/{reviewId} {
       allow read: if true;
 
-      // 리뷰 생성자만 수정/삭제 가능
+      // 리뷰 생성자만 전체 update/delete 가능
       allow update, delete: if isSignedIn() && isOwner(resource.data.createdBy.uid);
 
-      // likesCount만 바꾸는 경우 → 누구나 가능
+      // 예외적으로 likesCount만 수정할 수 있게 허용 (순서 중요: 아래쪽에 위치해야 함)
       allow update: if isSignedIn() &&
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likesCount']);
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -40,7 +40,7 @@ service cloud.firestore {
       match /comments/{commentId} {
         allow read: if true;
         allow create: if isSignedIn();
-        allow delete: if isSignedIn() && isOwner(resource.data.authorId);
+        allow delete: if isSignedIn() && isOwner(resource.data.author.uid);
       }
 
       // 하위 컬렉션: likes

--- a/src/components/review/CommentItem.jsx
+++ b/src/components/review/CommentItem.jsx
@@ -4,8 +4,8 @@ import { Trash2 } from "lucide-react";
 import { cn } from "utils/utils";
 
 export default function CommentItem({ comment, currentUserId, reviewId }) {
-  const { id, content, createdAt, authorId, authorName } = comment;
-  const isAuthor = currentUserId === authorId;
+  const { id, content, createdAt, author } = comment;
+  const isAuthor = currentUserId === author?.uid;
   const { mutate, isPending } = useDeleteComment(reviewId);
 
   const handleCommentDelete = () => {
@@ -18,11 +18,14 @@ export default function CommentItem({ comment, currentUserId, reviewId }) {
       {/* 작성자 & 시간 */}
       <div className="flex items-center gap-3 mb-2 text-sm text-gray-600">
         <img
-          src={comment.authorPhotoURL || "/default_profile.png"}
+          src={author?.photoURL || "/default_profile.png"}
           alt="작성자 프로필"
           className="w-6 h-6 rounded-full object-cover"
         />
-        <span className="font-semibold text-gray-800">{authorName}</span>
+        <span className="font-semibold text-gray-800">
+          {" "}
+          {author?.displayName || "익명"}
+        </span>
         <span className="text-gray-400 text-xs">
           {createdAt?.toDate?.()
             ? new Date(createdAt.toDate()).toLocaleString()

--- a/src/components/review/CommentList.jsx
+++ b/src/components/review/CommentList.jsx
@@ -17,8 +17,11 @@ export default function CommentList({ currentUserId, reviewId }) {
 
     mutate({
       content,
-      authorId: user.uid,
-      authorName: user.displayName || "익명",
+      author: {
+        uid: user.uid,
+        displayName: user.displayName || "익명",
+        photoURL: user.photoURL || "",
+      },
     });
 
     setContent("");

--- a/src/components/review/ReviewCard.jsx
+++ b/src/components/review/ReviewCard.jsx
@@ -11,7 +11,10 @@ import LikeButton from "components/review/LikeButton";
  * @param {string} props.review.destination - 여행지 이름
  * @param {string} props.review.content - 리뷰 내용
  * @param {number} props.review.rating - 평점 (1-5)
- * @param {string} props.review.authorName - 작성자 이름
+ * @param {Object} props.review.createdBy - 작성자 정보
+ * @param {string} props.review.createdBy.uid - 작성자 UID
+ * @param {string} props.review.createdBy.displayName - 작성자 이름
+ * @param {string} props.review.createdBy.photoURL - 작성자 프로필 이미지
  * @param {Object} props.review.createdAt - 작성 일시 (Firestore Timestamp)
  * @param {string} props.review.imageUrl - 이미지 URL (선택적)
  */
@@ -24,10 +27,9 @@ export default function ReviewCard({ review }) {
     destination,
     content,
     rating,
-    authorName,
+    createdBy,
     createdAt,
     imageUrl,
-    authorPhotoURL,
   } = review || {};
 
   const formattedDate =
@@ -99,10 +101,10 @@ export default function ReviewCard({ review }) {
         <div className="flex justify-between items-center mt-2">
           <div className="flex items-center gap-2">
             <span className="text-xs text-gray-500 truncate max-w-[100px]">
-              {authorName || "익명"}
+              {createdBy?.displayName || "익명"}
             </span>
             <img
-              src={authorPhotoURL || "/default_profile.png"}
+              src={createdBy?.photoURL || "/default_profile.png"}
               alt="작성자"
               className="w-5 h-5 rounded-full object-cover"
               onError={(e) => {

--- a/src/components/review/ReviewHero.jsx
+++ b/src/components/review/ReviewHero.jsx
@@ -2,15 +2,8 @@ import { formatDate } from "utils/formatDate";
 import { Star, MapPin } from "lucide-react";
 
 export default function ReviewHero({ review }) {
-  const {
-    title,
-    destination,
-    rating,
-    authorName,
-    authorPhotoURL,
-    createdAt,
-    imageUrl,
-  } = review || {};
+  const { title, destination, rating, createdBy, createdAt, imageUrl } =
+    review || {};
 
   return (
     <div className="relative h-[420px] w-full rounded-3xl overflow-hidden">
@@ -45,11 +38,11 @@ export default function ReviewHero({ review }) {
         {/* 작성자 + 날짜 */}
         <div className="flex items-center gap-3 mt-4 text-sm text-white/70">
           <img
-            src={authorPhotoURL || "/default_profile.png"}
+            src={createdBy?.photoURL || "/default_profile.png"}
             alt="작성자"
             className="w-6 h-6 rounded-full object-cover"
           />
-          <span>{authorName || "익명"}</span>
+          <span>{createdBy?.displayName || "익명"}</span>
           <span className="text-xs">· {formatDate(createdAt)}</span>
         </div>
       </div>

--- a/src/services/queries/review/useAddComment.js
+++ b/src/services/queries/review/useAddComment.js
@@ -1,17 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { collection, serverTimestamp, addDoc } from "firebase/firestore";
+import { useSelector } from "react-redux";
 import { db } from "services/firebase";
 
 export const useAddComment = (reviewId) => {
   const queryClient = useQueryClient();
+  const user = useSelector((state) => state.user.user);
 
   return useMutation({
-    mutationFn: async ({ content, authorId, authorName }) => {
+    mutationFn: async ({ content }) => {
+      if (!user) throw new Error("로그인이 필요합니다.");
+
       const commentRef = collection(db, "reviews", reviewId, "comments");
       await addDoc(commentRef, {
         content,
-        authorId,
-        authorName,
+        author: {
+          uid: user.uid,
+          displayName: user.displayName || "익명",
+          photoURL: user.photoURL || "",
+        },
         createdAt: serverTimestamp(),
       });
     },

--- a/src/services/queries/review/useAddReview.js
+++ b/src/services/queries/review/useAddReview.js
@@ -83,13 +83,10 @@ export default function useAddReview({
           displayName: user.displayName || "익명",
           photoURL: user.photoURL || "",
         },
-        authorName: user.displayName || "익명",
-        authorPhotoURL: user.photoURL || "",
         createdAt: serverTimestamp(),
         likeCount: 0,
         commentCount: 0,
         type,
-        userId: user.uid,
       };
 
       if (type === "standard") {

--- a/src/services/queries/review/useReportReview.js
+++ b/src/services/queries/review/useReportReview.js
@@ -53,7 +53,7 @@ export const useReportReview = () => {
         throw new Error("이미 신고한 리뷰입니다.");
       }
 
-      // 1. 리뷰 문서에서 작성자(authorId) 조회
+      // 1. 리뷰 문서에서 작성자 조회
       const reviewRef = doc(db, "reviews", reviewId);
       const reviewSnap = await getDoc(reviewRef);
 
@@ -61,7 +61,12 @@ export const useReportReview = () => {
         throw new Error("신고 대상 리뷰를 찾을 수 없습니다.");
       }
 
-      const { authorId } = reviewSnap.data();
+      const reviewData = reviewSnap.data();
+      const authorUid = reviewData.createdBy?.uid;
+
+      if (!authorUid) {
+        throw new Error("리뷰 작성자의 UID를 찾을 수 없습니다.");
+      }
 
       // 2. 신고 문서 추가
       await addDoc(collection(db, "review_reports"), {
@@ -72,8 +77,8 @@ export const useReportReview = () => {
         status: "pending",
       });
 
-      // 3. 리뷰 작성자(authorId)의 신고당한 횟수 증가
-      await updateDoc(doc(db, "users", authorId), {
+      // 3. 리뷰 작성자의 신고당한 횟수 증가
+      await updateDoc(doc(db, "users", authorUid), {
         reportedCount: increment(1),
       });
     },

--- a/src/services/reviewService.js
+++ b/src/services/reviewService.js
@@ -43,6 +43,10 @@ export const updateReviewData = async (id, updatedData) => {
       updatedAt: serverTimestamp(),
     };
 
+    if (updatedData.type === "standard") {
+      dataToUpdate.content = updatedData.content;
+    }
+
     await updateDoc(docRef, dataToUpdate);
     return true;
   } catch (error) {


### PR DESCRIPTION
## 주요 변경 사항

### Firestore 구조 리팩토링
- reviews 컬렉션 구조 정비: createdBy 객체 도입 (uid, displayName, photoURL)
- 기존의 authorName, userId, authorPhotoURL 제거
- 댓글(comment), 좋아요(like), 신고(report) 기능 전반에서 createdBy 기준으로 통일

### 댓글, 좋아요, 신고 기능 개선
- 댓글 작성자 구조를 author → author: { uid, displayName, photoURL }로 변경
- 좋아요수 정렬을 위한 likesCount 필드 도입 및 초기화
- 리뷰 신고 시 authorId → createdBy.uid 기반으로 처리 변경

### Firestore 보안 규칙 업데이트
- 리뷰 수정/삭제 권한을 createdBy.uid 기준으로 설정
- 좋아요 수 변경만 허용하는 별도 update 규칙 추가 (likesCount 예외 처리)
- 댓글 삭제 권한도 author.uid 기준으로 변경
