### PR TITLE
refactor: 일정 & 채팅 Firestore 구조 개선 + 보안 규칙 업데이트

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,23 +27,20 @@ service cloud.firestore {
     match /reviews/{reviewId} {
       allow read: if true;
 
-      // 리뷰 생성자만 전체 update/delete 가능
       allow update, delete: if isSignedIn() && isOwner(resource.data.createdBy.uid);
 
-      // 예외적으로 likesCount만 수정할 수 있게 허용 (순서 중요: 아래쪽에 위치해야 함)
+      // 예외적으로 likesCount만 수정할 수 있게 허용
       allow update: if isSignedIn() &&
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likesCount']);
 
       allow create: if isSignedIn();
 
-      // 하위 컬렉션: comments
       match /comments/{commentId} {
         allow read: if true;
         allow create: if isSignedIn();
         allow delete: if isSignedIn() && isOwner(resource.data.author.uid);
       }
 
-      // 하위 컬렉션: likes
       match /likes/{userId} {
         allow read, write: if isSignedIn();
       }
@@ -51,9 +48,7 @@ service cloud.firestore {
 
     match /users_public/{userId} {
       allow read: if true;
-
-      allow update: if isSignedIn() && isOwner(userId);
-      allow create: if isSignedIn() && isOwner(userId);
+      allow update, create: if isSignedIn() && isOwner(userId);
     }
 
     match /users_private/{userId} {
@@ -62,13 +57,11 @@ service cloud.firestore {
       allow update: if isSignedIn() && (
         isOwner(userId) || isAdmin() ||
 
-        // 신고 횟수 +1만 허용
         (
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reportedCount']) &&
           request.resource.data.reportedCount == resource.data.reportedCount + 1
         ) ||
 
-        // 일정 수 +1 또는 -1만 허용
         (
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['itineraryCount']) &&
           (
@@ -77,13 +70,12 @@ service cloud.firestore {
           )
         ) ||
 
-        // 리뷰 수 +1 또는 -1만 허용
         (
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reviewCount']) &&
           (
             request.resource.data.reviewCount == resource.data.reviewCount + 1 ||
             request.resource.data.reviewCount == resource.data.reviewCount - 1
-        )
+          )
         )
       );
 
@@ -92,25 +84,25 @@ service cloud.firestore {
 
     match /chatRooms/{roomId} {
       allow read: if isSignedIn();
+      allow create: if isSignedIn() &&
+        request.resource.data.createdBy.uid == request.auth.uid;
 
-      // write 시점에 문서가 없는 경우도 감안
-      allow write: if isSignedIn();
+      // 참가자 등록을 위해 "participants"만 수정할 수 있게 허용
+      allow update: if isSignedIn() && (
+        request.auth.uid in resource.data.participants || 
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["participants"])
+      );
 
-      // 기존 문서 기준 update 제한
-      allow update, delete: if isSignedIn() && request.auth.uid in resource.data.participants;
-
-      allow create: if isSignedIn();
+      allow delete: if isSignedIn() && request.auth.uid in resource.data.participants;
     }
 
     match /chatMessages/{messageId} {
       allow read: if isSignedIn();
-
       allow create: if isSignedIn() && (
-        // 일반 메시지
-        ((request.resource.data.type == null || request.resource.data.type == "text") &&
-      request.resource.data.senderId == request.auth.uid)
-
-        // 시스템 메시지
+        (
+          (!("type" in request.resource.data) || request.resource.data.type == "text") &&
+          request.resource.data.sender.uid == request.auth.uid
+        )
         || (
           request.resource.data.type == "system" &&
           request.resource.data.systemType in ["join", "leave", "date"] &&
@@ -130,7 +122,7 @@ service cloud.firestore {
     }
 
     match /chatReports/{reportId} {
-      allow create: if isSignedIn() && request.auth.uid == request.resource.data.reporterId;
+      allow create: if isSignedIn() && request.resource.data.reporterId == request.auth.uid;
       allow read, delete: if isAdmin();
 
       match /{sub=**} {
@@ -144,7 +136,7 @@ service cloud.firestore {
       allow write, create: if isSignedIn() && isAdmin();
     }
 
-    // 나머지 모든 문서는 차단
+    // catch-all: 나머지 문서 차단
     match /{document=**} {
       allow read, write: if false;
     }

--- a/src/components/chat/ChatMessage.jsx
+++ b/src/components/chat/ChatMessage.jsx
@@ -10,14 +10,16 @@ export default function ChatMessage({ message }) {
   const user = useSelector((state) => state.user.user);
   const {
     id,
-    senderId,
-    senderName,
+    sender,
     message: messageText,
     roomId,
     createdAt,
+    type,
+    systemType,
+    userName,
   } = message;
 
-  const isMine = senderId === user?.uid;
+  const isMine = sender?.uid === user?.uid;
   const [openReportModal, setOpenReportModal] = useState(false);
 
   const reportMutation = useReportMessage();
@@ -34,10 +36,10 @@ export default function ChatMessage({ message }) {
       });
   };
 
-  if (message.type === "system") {
+  if (type === "system") {
     const systemTextStyles = "text-center text-[12px] my-4";
 
-    switch (message.systemType) {
+    switch (systemType) {
       case "date":
         return (
           <div className="flex justify-center my-6">
@@ -46,25 +48,22 @@ export default function ChatMessage({ message }) {
             </span>
           </div>
         );
-
       case "join":
         return (
           <div className={`${systemTextStyles} text-gray-600`}>
             <span className="font-semibold text-gray-800 underline">
-              {message.userName}
+              {userName}
             </span>
             님이 여행 이야기에 합류했어요
           </div>
         );
-
       case "leave":
         return (
           <div className={`${systemTextStyles} text-gray-400 italic`}>
-            <span className="font-bold text-gray-500">{message.userName}</span>
+            <span className="font-bold text-gray-500">{userName}</span>
             님이 다른 여행지를 향해 떠났어요
           </div>
         );
-
       default:
         return null;
     }
@@ -75,14 +74,14 @@ export default function ChatMessage({ message }) {
       <div className="max-w-xs">
         {!isMine && (
           <img
-            src={message.senderPhotoURL || "/default_profile.png"}
-            alt={message.senderName}
+            src={sender?.photoURL || "/default_profile.png"}
+            alt={sender?.displayName || "익명"}
             className="w-6 h-6 rounded-full object-cover mr-2"
           />
         )}
         {!isMine && (
           <p className="text-xs font-semibold text-gray-700 mb-1">
-            {senderName}
+            {sender?.displayName || "익명"}
           </p>
         )}
 

--- a/src/components/chat/ChatRoomDetail.jsx
+++ b/src/components/chat/ChatRoomDetail.jsx
@@ -153,8 +153,8 @@ export default function ChatRoomDetail({ roomId }) {
         <div className="flex-1 flex flex-col">
           {/* 상단 헤더 */}
           <ChatHeader
-            title={roomInfo.name}
-            userName={roomInfo.createdByName || "상대 이름"}
+            title={roomInfo.name || "채팅방"}
+            userName={roomInfo.createdBy?.displayName || "익명"}
             onLeave={handleLeaveRoom}
           />
 

--- a/src/components/chat/ChatRoomForm.jsx
+++ b/src/components/chat/ChatRoomForm.jsx
@@ -51,8 +51,7 @@ export default function ChatRoomForm() {
         title,
         description,
         category,
-        uid: user.uid,
-        userName: user.displayName || "알 수 없음",
+        user,
       });
       navigate("/chat");
     } catch (err) {

--- a/src/components/chat/ChatRoomList.jsx
+++ b/src/components/chat/ChatRoomList.jsx
@@ -28,7 +28,7 @@ export default function ChatRoomList() {
     // 2. 검색 필터링
     if (searchKeyword.trim()) {
       result = result.filter((room) =>
-        room.title?.toLowerCase().includes(searchKeyword.trim().toLowerCase())
+        room.name?.toLowerCase().includes(searchKeyword.trim().toLowerCase())
       );
     }
 

--- a/src/components/chat/MessageInput.jsx
+++ b/src/components/chat/MessageInput.jsx
@@ -26,9 +26,11 @@ export default function MessageInput({ roomId }) {
         type: "text",
         roomId,
         message: message.trim(),
-        senderId: user.uid,
-        senderName: user.displayName || "익명",
-        senderPhotoURL: user.photoURL || "",
+        sender: {
+          uid: user.uid,
+          displayName: user.displayName || "익명",
+          photoURL: user.photoURL || "",
+        },
         createdAt: serverTimestamp(),
       });
       setMessage("");

--- a/src/services/itineraryService.js
+++ b/src/services/itineraryService.js
@@ -189,7 +189,11 @@ export const updateItinerary = async (id, updatedData) => {
 
     // Firestore에 저장할 데이터 준비
     const dataToUpdate = {
-      ...updatedData,
+      title: updatedData.title,
+      location: updatedData.location,
+      summary: updatedData.summary,
+      startDate: updatedData.startDate,
+      endDate: updatedData.endDate,
       imageUrl,
       updatedAt: serverTimestamp(),
     };

--- a/src/services/queries/chat/useReportMessage.js
+++ b/src/services/queries/chat/useReportMessage.js
@@ -76,7 +76,11 @@ export const useReportMessage = () => {
           throw new Error("신고 대상 메시지를 찾을 수 없습니다.");
         }
 
-        const { senderId } = messageSnap.data();
+        const { sender } = messageSnap.data();
+
+        if (!sender?.uid) {
+          throw new Error("신고 대상 사용자 정보를 찾을 수 없습니다.");
+        }
 
         // 2. 신고 문서 추가
         await addDoc(collection(db, "chatReports"), {
@@ -88,7 +92,7 @@ export const useReportMessage = () => {
         });
 
         // 3. senderId 기준으로 신고당한 유저의 reportedCount 증가
-        await updateDoc(doc(db, "users", senderId), {
+        await updateDoc(doc(db, "users", sender.uid), {
           reportedCount: increment(1),
         });
       } catch (error) {

--- a/src/services/queries/itinerary/useAddItinerary.js
+++ b/src/services/queries/itinerary/useAddItinerary.js
@@ -42,6 +42,7 @@ export const useAddItinerary = ({
           uid: user.uid,
           displayName: user.displayName || "익명",
           photoURL: user.photoURL || "",
+          userId: user.uid,
         },
       };
       return createItinerary(itineraryData);

--- a/src/services/queries/itinerary/useItineraries.js
+++ b/src/services/queries/itinerary/useItineraries.js
@@ -15,12 +15,22 @@ export const useItineraries = () => {
       );
       const snapshot = await getDocs(q);
 
-      return snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-        createdAt: doc.data().createdAt?.toDate() || new Date(),
-        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-      }));
+      return snapshot.docs.map((doc) => {
+        const data = doc.data();
+
+        return {
+          id: doc.id,
+          ...data,
+          createdAt: data.createdAt?.toDate() || new Date(),
+          updatedAt: data.updatedAt?.toDate() || new Date(),
+          createdBy: {
+            uid: data.createdBy?.uid || "",
+            displayName: data.createdBy?.displayName || "익명",
+            photoURL: data.createdBy?.photoURL || "/default_profile.png",
+          },
+          // startDate, endDate는 이후 개선 예정
+        };
+      });
     },
     onError: (err) => {
       console.error("일정 데이터를 불러오는 중 오류 발생:", err);


### PR DESCRIPTION
### 주요 변경 사항

#### 공통
- 모든 사용자 관련 필드를 createdBy: { uid, displayName, photoURL } 형태로 구조 통일
- userId 필드는 기존 쿼리 호환을 위해 유지 (명시적으로 추가)
- 관련 컬렉션에 맞춰 보안 규칙(firestore.rules) 업데이트

#### 일정 관련 변경
- createItinerary, useAddItinerary 등에서 createdBy, userId 명확히 지정
- useItineraries 훅에서 createdBy 기본값 보완
- 일정 카드 컴포넌트에서 구조 변경 대응 (작성자 정보 렌더링)

#### 채팅 관련 변경
- useCreateChatRoom, ChatRoomCard, ChatRoomDetail, ParticipantList 등에서
- createdBy: { uid, displayName, photoURL } 구조로 변경
- 채팅 메시지 전송 시 sender 필드를 객체화 → sender: { uid, displayName, photoURL }
- 메시지 신고 로직 senderId → sender.uid로 수정
- 채팅방 목록 검색 시 title → name 필드 기준으로 정렬/검색 작동
- Firestore 보안 규칙에 맞춰 chatRooms, chatMessages, chatReports 허용 조건 정비

#### Firestore 보안 규칙
- chatRooms 생성: createdBy.uid가 로그인 유저와 일치할 때만 허용
- chatMessages 생성: sender.uid 또는 system 메시지에 대한 검증 로직 추가
- 신고 문서(chatReports, review_reports)는 reporterId가 본인일 경우만 생성 가능

#### 기타
- 일부 API/훅에서 dataToUpdate로 명시적 필드 지정