### PR TITLE
fix: 리뷰 좋아요순 정렬 오류 및 신고 권한 문제 수정

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -113,11 +113,15 @@ service cloud.firestore {
 
     match /review_reports/{reportId} {
       allow create: if isSignedIn() && request.auth.uid == request.resource.data.reporterId;
-      allow read, delete: if isAdmin();
+
+      // 생성한 사용자가 읽을 수 있도록 read 허용
+      allow read: if isSignedIn() && resource.data.reporterId == request.auth.uid;
+
+      allow delete: if isAdmin();
 
       match /{sub=**} {
-        allow read, write: if isSignedIn();
-        allow read, delete: if isAdmin();
+        allow read, write: if isSignedIn(); // 필요시 조건 추가
+        allow delete: if isAdmin();
       }
     }
 

--- a/src/components/review/ReviewList.jsx
+++ b/src/components/review/ReviewList.jsx
@@ -25,7 +25,7 @@ export default function ReviewList() {
     } else if (sort === "rating") {
       result.sort((a, b) => b.rating - a.rating);
     } else if (sort === "likes") {
-      result.sort((a, b) => (b.likes?.length || 0) - (a.likes?.length || 0));
+      result.sort((a, b) => (b.likesCount || 0) - (a.likesCount || 0));
     }
 
     // 검색


### PR DESCRIPTION
### 주요 변경 사항
1. 리뷰 목록 좋아요순 정렬 오류 수정
- likesCount 필드가 제대로 반영되지 않아 정렬이 동작하지 않던 문제 해결
- 정렬 기준 b.likes?.length || 0 → b.likesCount로 수정하여 정상 정렬 처리

2. 리뷰 신고 문서에 대한 읽기 권한 추가
- 사용자가 자신이 생성한 신고 내역을 조회하지 못하던 문제 해결
- Firestore 보안 규칙에 resource.data.reporterId == request.auth.uid 조건의 read 권한 추가