### PR TITLE
fix: 일정이 없을 때 Hero 섹션과 생성 카드가 렌더링되지 않던 문제 수정

### DIFF
--- a/src/components/itinerary/ItineraryList.jsx
+++ b/src/components/itinerary/ItineraryList.jsx
@@ -3,7 +3,6 @@ import { useItineraries } from "services/queries/itinerary/useItineraries";
 
 import ItineraryCard from "./ItineraryCard";
 import LoadingSpinner from "components/common/LoadingSpinner";
-import EmptyState from "components/common/EmptyState";
 import { Search } from "lucide-react";
 import CreateCard from "components/common/CreateCard";
 import HeroSection from "components/common/HeroSection";
@@ -64,14 +63,7 @@ export default function ItineraryList() {
       </div>
     );
 
-  if (!itineraries || itineraries.length === 0)
-    return (
-      <EmptyState
-        icon="📅"
-        title="등록된 일정이 없습니다"
-        description="당신의 여행 일정을 공유해보세요!"
-      />
-    );
+  if (isLoading) return <LoadingSpinner />;
 
   return (
     <>


### PR DESCRIPTION

일정이 없을 때 상단 HeroSection과 일정 생성 카드(CreateCard)가 렌더링되지 않던 문제를 해결했습니다.
기존 구현에서는 itineraries.length === 0 조건일 경우 전체 섹션이 렌더링되지 않아, 필터 버튼 및 검색창도 보이지 않았습니다.
일정 유무와 관계없이 Hero 섹션과 생성 카드가 항상 표시되도록 구조를 개선했습니다.