### PR TITLE
fix: 메인 페이지 리뷰 섹션 닉네임/프로필 표시 오류 수정 (createdBy 경로 적용)

### DIFF
--- a/src/components/home/ReviewPreview.jsx
+++ b/src/components/home/ReviewPreview.jsx
@@ -68,13 +68,13 @@ export default function ReviewPreview() {
                 {/* 유저 정보 */}
                 <div className="flex gap-4 items-center mb-4">
                   <img
-                    src={review.authorPhoto || "/default_profile.png"}
+                    src={review.createdBy?.photoURL || "/default_profile.png"}
                     alt="작성자"
                     className="w-14 h-14 object-cover rounded-full border border-white/20"
                   />
                   <div>
                     <p className="font-bold text-base">
-                      {review.authorName || "익명"}
+                      {review.createdBy?.displayName || "익명"}
                     </p>
                     <p className="text-xs opacity-60">
                       {review.destination || "여행지"} ·{" "}


### PR DESCRIPTION
### 메인 페이지 리뷰 닉네임/프로필 표시 오류 수정

- Firestore 컬렉션 구조 변경에 따라 리뷰 작성자 정보를 `createdBy.displayName`, `createdBy.photoURL`에서 가져오도록 수정
- 기존 `review.authorName`, `review.authorPhoto` → 존재하지 않아 undefined 발생하던 문제 해결