### PR TITLE
 feat: 계정 탈퇴 기능 최종 구현 및 익명화 처리 반영(프로필, 일정, 리뷰, 채팅)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,20 +19,27 @@ service cloud.firestore {
     }
 
     match /itineraries/{itineraryId} {
-      allow read: if isSignedIn();
-      allow create: if isSignedIn();
-      allow update, delete: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
+      allow read, create: if isSignedIn();
+
+      allow update: if isSignedIn() && (
+        resource.data.createdBy.uid == request.auth.uid ||
+        request.resource.data.diff(resource.data).affectedKeys()
+          .hasOnly(["createdBy.displayName", "createdBy.photoURL"])
+      );
+
+      allow delete: if isSignedIn() && resource.data.createdBy.uid == request.auth.uid;
     }
 
     match /reviews/{reviewId} {
       allow read: if true;
 
-      allow update, delete: if isSignedIn() && isOwner(resource.data.createdBy.uid);
+      allow update: if isSignedIn() && (
+        isOwner(resource.data.createdBy.uid) ||
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["likesCount"]) ||
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["createdBy.displayName", "createdBy.photoURL"])
+      );
 
-      // 예외적으로 likesCount만 수정할 수 있게 허용
-      allow update: if isSignedIn() &&
-        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likesCount']);
-
+      allow delete: if isSignedIn() && isOwner(resource.data.createdBy.uid);
       allow create: if isSignedIn();
 
       match /comments/{commentId} {
@@ -83,14 +90,16 @@ service cloud.firestore {
     }
 
     match /chatRooms/{roomId} {
-      allow read: if isSignedIn();
-      allow create: if isSignedIn() &&
-        request.resource.data.createdBy.uid == request.auth.uid;
+      allow read, create: if isSignedIn();
 
-      // 참가자 등록을 위해 "participants"만 수정할 수 있게 허용
       allow update: if isSignedIn() && (
         request.auth.uid in resource.data.participants || 
-        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["participants"])
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(["participants"]) ||
+        (
+          request.auth.uid == resource.data.createdBy.uid &&
+          request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(["createdBy.displayName", "createdBy.photoURL"])
+        )
       );
 
       allow delete: if isSignedIn() && request.auth.uid in resource.data.participants;
@@ -98,6 +107,7 @@ service cloud.firestore {
 
     match /chatMessages/{messageId} {
       allow read: if isSignedIn();
+
       allow create: if isSignedIn() && (
         (
           (!("type" in request.resource.data) || request.resource.data.type == "text") &&
@@ -108,6 +118,17 @@ service cloud.firestore {
           request.resource.data.systemType in ["join", "leave", "date"] &&
           request.resource.data.userId == request.auth.uid
         )
+      );
+
+      // 익명화 처리를 위한 update 허용
+      allow update: if isSignedIn()
+      && request.auth.uid == resource.data.sender.uid
+      && (
+       // sender 객체 전체가 덮어써질 때
+       request.resource.data.diff(resource.data).affectedKeys().hasOnly(["sender"])
+       // 또는 sender 내부 필드만 바뀔 때
+       || request.resource.data.diff(resource.data).affectedKeys()
+          .hasOnly(["sender.displayName", "sender.photoURL"])
       );
     }
 

--- a/src/components/modal/DeleteAccountModal.jsx
+++ b/src/components/modal/DeleteAccountModal.jsx
@@ -4,10 +4,18 @@ import { X, AlertTriangle } from "lucide-react";
 import PropTypes from "prop-types";
 import ErrorMessage from "components/common/ErrorMessage";
 
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "services/firebase";
+
 export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+
+  const [user] = useAuthState(auth);
+  const isPasswordUser = user?.providerData?.some(
+    (p) => p.providerId === "password"
+  );
 
   const handleConfirm = async () => {
     if (!password.trim()) {
@@ -61,19 +69,26 @@ export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
               </p>
             </div>
 
-            <p className="text-sm text-gray-700">
-              탈퇴를 위해 비밀번호를 다시 입력해주세요.
-            </p>
-
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="현재 비밀번호"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
-            />
-
-            <ErrorMessage message={error} />
+            {isPasswordUser ? (
+              <>
+                <p className="text-sm text-gray-700">
+                  탈퇴를 위해 비밀번호를 다시 입력해주세요.
+                </p>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="현재 비밀번호"
+                  className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
+                />
+                <ErrorMessage message={error} />
+              </>
+            ) : (
+              <p className="text-sm text-gray-700">
+                이 계정은 소셜 로그인으로 가입되었습니다. 별도 비밀번호 확인
+                없이 탈퇴할 수 있습니다.
+              </p>
+            )}
 
             <div className="flex justify-end gap-3 mt-4">
               <button
@@ -83,8 +98,8 @@ export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
                 취소
               </button>
               <button
-                onClick={handleConfirm}
-                disabled={isLoading}
+                onClick={() => (isPasswordUser ? handleConfirm() : onConfirm())}
+                disabled={isLoading || (isPasswordUser && !password)}
                 className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700"
               >
                 {isLoading ? "탈퇴 중..." : "탈퇴하기"}

--- a/src/components/modal/DeleteAccountModal.jsx
+++ b/src/components/modal/DeleteAccountModal.jsx
@@ -62,11 +62,30 @@ export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
 
           {/* 내용 */}
           <div className="space-y-4">
-            <div className="flex items-center gap-3 text-red-600">
-              <AlertTriangle className="w-5 h-5" />
-              <p className="text-sm">
-                작성한 리뷰, 일정, 채팅방 기록이 모두 삭제됩니다.
-              </p>
+            <div className="flex items-start gap-3 text-red-600">
+              <AlertTriangle className="w-5 h-5 mt-1" />
+              <div className="text-sm text-gray-700 space-y-1">
+                <p>
+                  작성한{" "}
+                  <strong className="text-red-700 font-medium">
+                    리뷰, 일정, 채팅방 기록은 삭제되지 않습니다.
+                  </strong>
+                </p>
+                <p>
+                  대신, 작성자 정보는{" "}
+                  <strong className="text-red-700 font-medium">
+                    "탈퇴한 사용자"
+                  </strong>
+                  로 익명 처리됩니다.
+                </p>
+                <p>
+                  기록 삭제를 원하실 경우,{" "}
+                  <strong className="text-red-700 font-medium">
+                    관리자에게 별도로 문의
+                  </strong>
+                  해 주세요.
+                </p>
+              </div>
             </div>
 
             {isPasswordUser ? (

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -25,6 +25,7 @@ import { Camera, Edit, LogOut, Settings } from "lucide-react";
 import SettingModal from "components/modal/SettingModal";
 import ChangePasswordModal from "components/modal/ChangePasswordModal";
 import DeleteAccountModal from "components/modal/DeleteAccountModal";
+import { anonymizeUserContent } from "utils/deleteAccount";
 
 export default function ProfileSection() {
   const user = useSelector((state) => state.user.user);
@@ -109,6 +110,7 @@ export default function ProfileSection() {
 
       // 2. 익명화
       await anonymizePublicProfile(uid);
+      await anonymizeUserContent(uid);
 
       // 3. 계정 삭제
       await deleteUser(user);

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -119,7 +119,6 @@ export default function ProfileSection() {
       dispatch(clearUser());
       navigate("/");
     } catch (err) {
-      console.error("계정 탈퇴 실패:", err);
       alert("계정 탈퇴 중 오류가 발생했습니다: " + err.message);
     }
   };

--- a/src/utils/deleteAccount.js
+++ b/src/utils/deleteAccount.js
@@ -1,4 +1,11 @@
-import { doc, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 import { db } from "services/firebase";
 
 /**
@@ -11,4 +18,47 @@ export const anonymizePublicProfile = async (uid) => {
     displayName: "탈퇴한 사용자",
     photoURL: "/default_profile.png",
   });
+};
+
+export const anonymizeUserContent = async (uid) => {
+  const reviewQ = query(
+    collection(db, "reviews"),
+    where("createdBy.uid", "==", uid)
+  );
+  const itineraryQ = query(
+    collection(db, "itineraries"),
+    where("createdBy.uid", "==", uid)
+  );
+  const chatRoomQ = query(
+    collection(db, "chatRooms"),
+    where("createdBy.uid", "==", uid)
+  );
+  const messageQ = query(
+    collection(db, "messages"),
+    where("sender.uid", "==", uid)
+  );
+
+  const anonymizeDocs = async (querySnapshot, path) => {
+    const promises = querySnapshot.docs.map((doc) =>
+      updateDoc(doc.ref, {
+        [`${path}.displayName`]: "탈퇴한 사용자",
+        [`${path}.photoURL`]: "",
+      })
+    );
+    await Promise.all(promises);
+  };
+
+  const [reviews, itineraries, chatRooms, messages] = await Promise.all([
+    getDocs(reviewQ),
+    getDocs(itineraryQ),
+    getDocs(chatRoomQ),
+    getDocs(messageQ),
+  ]);
+
+  await Promise.all([
+    anonymizeDocs(reviews, "createdBy"),
+    anonymizeDocs(itineraries, "createdBy"),
+    anonymizeDocs(chatRooms, "createdBy"),
+    anonymizeDocs(messages, "sender"),
+  ]);
 };

--- a/src/utils/deleteAccount.js
+++ b/src/utils/deleteAccount.js
@@ -34,7 +34,7 @@ export const anonymizeUserContent = async (uid) => {
     where("createdBy.uid", "==", uid)
   );
   const messageQ = query(
-    collection(db, "messages"),
+    collection(db, "chatMessages"),
     where("sender.uid", "==", uid)
   );
 
@@ -48,17 +48,19 @@ export const anonymizeUserContent = async (uid) => {
     await Promise.all(promises);
   };
 
-  const [reviews, itineraries, chatRooms, messages] = await Promise.all([
-    getDocs(reviewQ),
-    getDocs(itineraryQ),
-    getDocs(chatRoomQ),
-    getDocs(messageQ),
-  ]);
+  try {
+    const [reviews, itineraries, chatRooms, messages] = await Promise.all([
+      getDocs(reviewQ),
+      getDocs(itineraryQ),
+      getDocs(chatRoomQ),
+      getDocs(messageQ),
+    ]);
 
-  await Promise.all([
-    anonymizeDocs(reviews, "createdBy"),
-    anonymizeDocs(itineraries, "createdBy"),
-    anonymizeDocs(chatRooms, "createdBy"),
-    anonymizeDocs(messages, "sender"),
-  ]);
+    await anonymizeDocs(reviews, "createdBy");
+    await anonymizeDocs(itineraries, "createdBy");
+    await anonymizeDocs(chatRooms, "createdBy");
+    await anonymizeDocs(messages, "sender");
+  } catch (err) {
+    throw err;
+  }
 };


### PR DESCRIPTION
### 주요 변경 사항
- 계정 탈퇴 로직 완성
  - 이메일 재인증 후, 사용자 계정 삭제
  - 사용자 정보는 users_public, reviews, itineraries, chatRooms, chatMessages 등에서 익명화 처리 (displayName, photoURL 변경)
  - Firestore 보안 규칙 정비: 익명화 목적의 특정 필드만 update 가능하도록 조건 허용
- 소셜 로그인 유저 분기 처리
  - 이메일/비밀번호 유저는 재인증 후 탈퇴 진행
  - 소셜 로그인 유저는 별도 비밀번호 없이 탈퇴 가능
- 탈퇴 안내 문구 개선
  - “작성한 기록은 삭제되지 않으며, 작성자 정보는 익명 처리됩니다”라는 문구로 사용자 오해 방지
  - 기록 삭제를 원할 경우 관리자에게 별도 문의하라는 안내 추가
- UX 개선
- 탈퇴 중 로딩 처리 및 예외 에러 대응 강화
- 모달 구조 개선 및 사용자 피드백 반영
