### PR TITLE
feat: 메인 페이지 추천 여행지 섹션 Firestore 연동

### DIFF
--- a/src/components/home/DestinationSlider.jsx
+++ b/src/components/home/DestinationSlider.jsx
@@ -43,7 +43,7 @@ export default function DestinationSlider() {
             1024: { slidesPerView: 4 },
           }}
         >
-          {destinations.map((place) => (
+          {destinations.slice(0, 8).map((place) => (
             <SwiperSlide key={place.id}>
               <Link
                 to={`/recommendations/${place.id}`}

--- a/src/components/home/DestinationSlider.jsx
+++ b/src/components/home/DestinationSlider.jsx
@@ -4,36 +4,13 @@ import "swiper/css";
 import "swiper/css/navigation";
 
 import { Link } from "react-router-dom";
-
-const destinations = [
-  {
-    name: "제주도",
-    desc: "힐링과 자연이 공존하는 섬",
-    image: "/images/jeju_island.jpg",
-  },
-  {
-    name: "부산",
-    desc: "바다와 도심의 조화",
-    image: "/images/busan_gamcheon_culture_village.jpg",
-  },
-  {
-    name: "경주",
-    desc: "역사와 고요함이 있는 도시",
-    image: "/images/gyeongju_hwarang.jpg",
-  },
-  {
-    name: "서울",
-    desc: "다채로운 문화와 미식의 중심",
-    image: "/images/seoul_night.jpg",
-  },
-  {
-    name: "강릉",
-    desc: "해돋이 명소와 커피 거리",
-    image: "/images/gangneung_beach.jpg",
-  },
-];
+import { useRecommendationList } from "hooks/useRecommendationList";
 
 export default function DestinationSlider() {
+  const { data: destinations, isLoading } = useRecommendationList();
+
+  if (isLoading || !destinations) return null;
+
   return (
     <section className="py-24 px-6 bg-gray-50 overflow-hidden">
       <div className="max-w-screen-2xl mx-auto">
@@ -66,16 +43,15 @@ export default function DestinationSlider() {
             1024: { slidesPerView: 4 },
           }}
         >
-          {destinations.slice(0, 8).map((d, idx) => (
-            <SwiperSlide key={idx}>
+          {destinations.map((place) => (
+            <SwiperSlide key={place.id}>
               <Link
-                to="/recommendations"
-                className="relative block w-full h-72 rounded-xl overflow-hidden shadow hover:brightness-105 transition"
+                to={`/recommendations/${place.id}`}
+                className="relative block w-full h-72 rounded-xl overflow-hidden shadow hover:brightness-105 transition bg-gray-200"
               >
-                {/* 이미지 */}
                 <img
-                  src={d.image}
-                  alt={d.name}
+                  src={place.imageUrl || "/images/placeholder.jpg"}
+                  alt={place.name}
                   onError={(e) => {
                     if (!e.target.dataset.fallback) {
                       e.target.src = "/images/placeholder.jpg";
@@ -84,12 +60,10 @@ export default function DestinationSlider() {
                   }}
                   className="w-full h-full object-cover"
                 />
-                {/* 오버레이 */}
                 <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" />
-                {/* 텍스트 */}
                 <div className="absolute bottom-4 left-4 text-white z-10">
-                  <h3 className="font-semibold text-lg">{d.name}</h3>
-                  <p className="text-sm">{d.desc}</p>
+                  <h3 className="font-semibold text-lg">{place.name}</h3>
+                  <p className="text-sm line-clamp-2">{place.summary}</p>
                 </div>
               </Link>
             </SwiperSlide>


### PR DESCRIPTION
- Firestore recommended_places 컬렉션에서 visible=true 조건의 여행지 불러오기
- useRecommendationList() 커스텀 훅 연결하여 데이터 fetch
- 누락된 .slice(0, 8) 슬라이더 최대 8개 제한 로직 재적용
- 추천 여행지 리스트 항목 클릭 시 상세 페이지(/recommendations/:id)로 이동 처리
- 이미지 누락 시 placeholder 처리 및 디자인 레이아웃 안정화