### PR TITLE
fix: 신고 처리 시 Firestore 컬렉션 경로 오류 및 권한 문제 해결

### DIFF
--- a/src/services/queries/chat/useReportMessage.js
+++ b/src/services/queries/chat/useReportMessage.js
@@ -92,7 +92,7 @@ export const useReportMessage = () => {
         });
 
         // 3. senderId 기준으로 신고당한 유저의 reportedCount 증가
-        await updateDoc(doc(db, "users", sender.uid), {
+        await updateDoc(doc(db, "users_private", sender.uid), {
           reportedCount: increment(1),
         });
       } catch (error) {

--- a/src/services/queries/review/useReportReview.js
+++ b/src/services/queries/review/useReportReview.js
@@ -72,13 +72,13 @@ export const useReportReview = () => {
       await addDoc(collection(db, "review_reports"), {
         reviewId,
         reason,
-        reporterId,
+        reporterId: user.uid,
         reportedAt: serverTimestamp(),
         status: "pending",
       });
 
       // 3. 리뷰 작성자의 신고당한 횟수 증가
-      await updateDoc(doc(db, "users", authorUid), {
+      await updateDoc(doc(db, "users_private", authorUid), {
         reportedCount: increment(1),
       });
     },


### PR DESCRIPTION
### 문제 원인
- 신고 처리 시 Firestore에서 삭제된 'users' 컬렉션에 접근하여 400 오류 발생
- 해당 컬렉션은 현재 사용되지 않으며, 보안 규칙에도 정의되어 있지 않음

### 해결 내용
- 신고 대상 유저의 `reportedCount` 업데이트 경로를 'users_private'로 수정
- 'users_private'에 대한 보안 규칙은 이미 업데이트 조건을 허용하고 있어 별도 수정 없음

### 영향 범위
- 리뷰 신고
- 채팅 메시지 신고

### 결과
- Firestore stream terminate 문제 해결
- 신고 기능 정상 동작 확인 완료