### PR TITLE
feat: 메인 페이지 지역 지도 섹션 기능 개선 및 Firebase 연동

### DIFF
--- a/src/components/home/RegionMapSection.jsx
+++ b/src/components/home/RegionMapSection.jsx
@@ -2,10 +2,20 @@ import { Link } from "react-router-dom";
 import { regions } from "data/regions";
 import { useState } from "react";
 
+import { useRegionCounts } from "services/queries/itinerary/useRegionCounts";
+
 export default function RegionMapSection() {
   const [activeRegion, setActiveRegion] = useState(null);
 
-  const totalCount = regions.reduce((acc, r) => acc + r.count, 0);
+  const { data: regionCounts, isLoading } = useRegionCounts();
+
+  if (!regionCounts) return null;
+
+  const mappedRegions = regions.map((r) => ({
+    ...r,
+    count: regionCounts[r.slug] || 0,
+  }));
+  const totalCount = Object.values(regionCounts).reduce((acc, v) => acc + v, 0);
 
   return (
     <section className="bg-gray-100 py-20 px-4 sm:px-6 lg:px-8">
@@ -52,7 +62,7 @@ export default function RegionMapSection() {
             className="w-full h-full object-contain"
           />
 
-          {regions.map((r) => (
+          {mappedRegions.map((r) => (
             <div
               key={r.slug}
               className="absolute -translate-x-1/2 -translate-y-1/2"

--- a/src/components/home/RegionMapSection.jsx
+++ b/src/components/home/RegionMapSection.jsx
@@ -5,38 +5,42 @@ import { useState } from "react";
 export default function RegionMapSection() {
   const [activeRegion, setActiveRegion] = useState(null);
 
+  const totalCount = regions.reduce((acc, r) => acc + r.count, 0);
+
   return (
     <section className="bg-gray-100 py-20 px-4 sm:px-6 lg:px-8">
       <div className="max-w-screen-2xl mx-auto flex flex-col lg:flex-row items-center justify-between gap-10">
         {/* 왼쪽 설명 */}
         <div className="flex-1 max-w-2xl pl-7">
           <h2 className="text-3xl font-bold text-gray-900 mb-2 text-left">
-            지금, 어디로 떠나고 싶나요?
+            지도에서 여행지를 골라보세요
           </h2>
           <p className="text-sm text-gray-500 mb-6 leading-relaxed">
-            감성 혼행자들이 자주 찾는 지역별 여행 일정. 지도를 클릭해 나만의
-            여정을 시작해보세요.
+            대한민국의 구석구석, 혼자 떠나기 좋은 일정들이 기다리고 있어요. 클릭
+            한 번으로 일정을 탐색하고, 마음에 드는 여정을 발견해보세요.
           </p>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4">
-            {regions.map((r) => (
-              <div key={r.slug} className="flex items-start gap-4">
-                <div className="w-10 h-10 rounded-full bg-black text-white flex items-center justify-center font-bold">
-                  {r.count}
-                </div>
-                <div>
-                  <p className="font-semibold">{r.name}</p>
-                  <p className="text-sm text-gray-500">{r.desc}</p>
-                </div>
-              </div>
-            ))}
+          {/* 전체 지역 요약 (예: 일정 수 총합, 인기 지역) */}
+          <div className="bg-white/60 rounded-xl shadow-sm px-6 py-4 mb-6 backdrop-blur-sm">
+            <p className="text-gray-800 text-sm leading-relaxed font-bold">
+              총 <span className="text-blue-700">{totalCount}</span>
+              개의 일정이{" "}
+              <span className="text-blue-700">{regions.length}</span>개 지역에
+              걸쳐 등록되어 있어요.
+            </p>
+            <p className="text-xs text-gray-500 mt-3">
+              최근 인기 지역은{" "}
+              <span className="font-medium text-black">서울</span>과{" "}
+              <span className="font-medium text-black">제주도</span>입니다.
+            </p>
           </div>
 
+          {/* CTA 버튼 */}
           <Link
-            to={`/itinerary`}
-            className="inline-block mt-6 text-sm px-4 py-1.5 rounded-full border border-gray-300 text-gray-600 hover:bg-gray-50 transition"
+            to="/itinerary"
+            className="inline-block mt-5 px-5 py-2 rounded bg-black text-white text-sm hover:bg-gray-800"
           >
-            더 많은 일정 보러가기 →
+            전체 일정 보러가기 →
           </Link>
         </div>
 
@@ -54,11 +58,11 @@ export default function RegionMapSection() {
               className="absolute -translate-x-1/2 -translate-y-1/2"
               style={{ top: r.position.top, left: r.position.left }}
             >
-              {/* 설명 박스: 항상 z-50 이상 */}
+              {/* 설명 박스 */}
               {activeRegion === r.slug && (
-                <div className="absolute bottom-[56px] left-1/2 -translate-x-1/2 bg-white text-gray-800 rounded-xl shadow-xl px-4 py-3 w-[200px]">
+                <div className="absolute bottom-[56px] left-1/2 -translate-x-1/2 bg-gray-600 text-white rounded-xl shadow-xl px-4 py-3 w-[200px]">
                   <p className="font-semibold text-sm">{r.name}</p>
-                  <p className="text-xs text-gray-500 mt-1">{r.desc}</p>
+                  <p className="text-xs text-white mt-1">{r.desc}</p>
                 </div>
               )}
 

--- a/src/components/home/RegionMapSection.jsx
+++ b/src/components/home/RegionMapSection.jsx
@@ -1,7 +1,10 @@
 import { Link } from "react-router-dom";
 import { regions } from "data/regions";
+import { useState } from "react";
 
 export default function RegionMapSection() {
+  const [activeRegion, setActiveRegion] = useState(null);
+
   return (
     <section className="bg-gray-100 py-20 px-4 sm:px-6 lg:px-8">
       <div className="max-w-screen-2xl mx-auto flex flex-col lg:flex-row items-center justify-between gap-10">
@@ -38,7 +41,7 @@ export default function RegionMapSection() {
         </div>
 
         {/* 오른쪽 지도 */}
-        <div className="relative w-[480px] h-[480px] flex-shrink-0 mx-auto lg:mr-7">
+        <div className="relative w-[480px] h-[480px] flex-shrink-0 mx-auto lg:mr-7 z-0 overflow-visible">
           <img
             src="/images/korea-map.png"
             alt="대한민국 지도"
@@ -51,12 +54,22 @@ export default function RegionMapSection() {
               className="absolute -translate-x-1/2 -translate-y-1/2"
               style={{ top: r.position.top, left: r.position.left }}
             >
-              <Link
-                to={`/itineraries/${r.slug}`}
-                className="w-10 h-10 rounded-full bg-black text-white flex items-center justify-center font-bold text-sm shadow-md hover:scale-110 hover:ring-2 hover:ring-white transition"
+              {/* 설명 박스: 항상 z-50 이상 */}
+              {activeRegion === r.slug && (
+                <div className="absolute bottom-[56px] left-1/2 -translate-x-1/2 bg-white text-gray-800 rounded-xl shadow-xl px-4 py-3 w-[200px]">
+                  <p className="font-semibold text-sm">{r.name}</p>
+                  <p className="text-xs text-gray-500 mt-1">{r.desc}</p>
+                </div>
+              )}
+
+              <button
+                onClick={() =>
+                  setActiveRegion(activeRegion === r.slug ? null : r.slug)
+                }
+                className="relative w-10 h-10 rounded-full bg-white/80 text-gray-900 font-semibold text-sm shadow-lg ring-2 ring-white backdrop-blur-sm flex items-center justify-center transition hover:scale-110"
               >
                 {r.count}
-              </Link>
+              </button>
             </div>
           ))}
         </div>

--- a/src/data/regions.js
+++ b/src/data/regions.js
@@ -18,7 +18,7 @@ export const regions = [
     slug: "gangwon",
     count: 18,
     desc: "자연과 함께하는 고요한 여행 장소들",
-    position: { top: "20%", left: "60%" },
+    position: { top: "25%", left: "65%" },
   },
   {
     name: "충청도",

--- a/src/services/queries/itinerary/useRegionCounts.js
+++ b/src/services/queries/itinerary/useRegionCounts.js
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "services/firebase";
+
+const LOCATION_MAP = {
+  서울: "seoul",
+  경기도: "seoul", // 서울 & 경기로 묶음
+  인천: "incheon",
+  강원도: "gangwon",
+  충청도: "chungcheong",
+  전라도: "jeolla",
+  경상도: "gyeongsang",
+  제주도: "jeju",
+};
+
+const fetchRegionCounts = async () => {
+  const snapshot = await getDocs(collection(db, "itineraries"));
+  const counts = {
+    seoul: 0,
+    incheon: 0,
+    gangwon: 0,
+    chungcheong: 0,
+    jeolla: 0,
+    gyeongsang: 0,
+    jeju: 0,
+  };
+
+  snapshot.forEach((doc) => {
+    const rawLoc = doc.data().location?.trim();
+    const mapped = LOCATION_MAP[rawLoc];
+    if (mapped) {
+      counts[mapped] += 1;
+    }
+  });
+
+  return counts;
+};
+
+export const useRegionCounts = () => {
+  return useQuery({
+    queryKey: ["regionCounts"],
+    queryFn: fetchRegionCounts,
+    staleTime: 5 * 60 * 1000,
+  });
+};


### PR DESCRIPTION
### 주요 변경 사항

1. 지도 마커 클릭 시 지역 설명 토글 기능 추가
- 마커 클릭 시 해당 지역의 간단한 설명을 보여주는 토글 박스 구현
- 중복 클릭 시 닫히는 방식 적용
- 설명 박스가 마커에 가려지는 z-index 문제는 완전히 해결되지 않아, 각 지역의 좌표를 수동 조정하여 시각적 충돌을 우회함 (향후 리팩토링 필요)

2. 좌측 요약 카드 및 CTA 버튼 스타일 개선
- 전체 지역 일정 수와 인기 지역을 강조하는 카드 추가
- 블러/라운드/서브톤 배경을 활용한 디자인 개선
- CTA 버튼에 슬레이트 계열 색상 적용 및 hover 스타일 향상

3. 지역별 일정 수 Firebase 연동
- Firestore itineraries 컬렉션의 location 필드 기반으로 slug별 일정 수 계산
- 서울, 경기는 "서울 & 경기"로 통합
- useRegionCounts 커스텀 훅에서 React Query로 fetch 및 캐싱
- 기존 하드코딩된 count 제거, 지도 마커 및 요약 카드에 실시간 데이터 반영
