### PR TITLE
refactor: 메인 페이지 섹션 공통 레이아웃 컴포넌트(MainSectionWrapper)로 분리 적용

### DIFF
--- a/src/components/common/layout/MainSectionWrapper.jsx
+++ b/src/components/common/layout/MainSectionWrapper.jsx
@@ -1,0 +1,15 @@
+export default function MainSectionWrapper({
+  children,
+  className = "",
+  containerClass = "",
+  bg = "bg-white",
+  padding = "py-32 px-6",
+}) {
+  return (
+    <section className={`relative ${padding} ${bg} ${className}`}>
+      <div className={`max-w-screen-2xl mx-auto ${containerClass}`}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/DestinationSlider.jsx
+++ b/src/components/home/DestinationSlider.jsx
@@ -6,6 +6,7 @@ import "swiper/css/navigation";
 import { Link } from "react-router-dom";
 import { useRecommendationList } from "@/hooks/recommendation/useRecommendationList";
 import SkeletonImage from "@/components/common/loading/SkeletonImage";
+import MainSectionWrapper from "@/components/common/layout/MainSectionWrapper";
 
 export default function DestinationSlider() {
   const { data: destinations, isLoading } = useRecommendationList();
@@ -13,7 +14,7 @@ export default function DestinationSlider() {
   if (isLoading || !destinations) return null;
 
   return (
-    <section className="py-24 px-6 bg-gray-50 overflow-hidden">
+    <MainSectionWrapper bg="bg-gray-50" className="overflow-hidden">
       <div className="max-w-screen-2xl mx-auto">
         {/* 제목 + 설명 */}
         <div className="text-center mb-12">
@@ -61,6 +62,6 @@ export default function DestinationSlider() {
           ))}
         </Swiper>
       </div>
-    </section>
+    </MainSectionWrapper>
   );
 }

--- a/src/components/home/NewsletterSection.jsx
+++ b/src/components/home/NewsletterSection.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import MainSectionWrapper from "@/components/common/layout/MainSectionWrapper";
 
 export default function NewsletterSection() {
   const [email, setEmail] = useState("");
@@ -13,7 +14,7 @@ export default function NewsletterSection() {
   };
 
   return (
-    <section className="relative h-[520px] px-6 py-12 overflow-hidden flex items-center justify-center">
+    <MainSectionWrapper className="overflow-hidden min-h-[520px]">
       {/* 배경 이미지 */}
       <img
         src="/images/newsletter-bg.jpg"
@@ -25,14 +26,11 @@ export default function NewsletterSection() {
       <div className="absolute inset-0 bg-black/40" />
 
       {/* 콘텐츠 */}
-      <div className="relative z-10 max-w-xl mx-auto text-center text-white">
+      <div className="relative z-10 flex flex-col items-center justify-center max-w-xl mx-auto text-center text-white py-12">
         <h2 className="text-2xl font-bold mb-4">
-          {" "}
           혼자 떠나는 이들을 위한 작은 안내서
         </h2>
-
         <p className="text-sm mb-8">
-          {" "}
           매월 엄선된 혼자 여행 코스와 혼행자들의 이야기를 받아보세요.
         </p>
 
@@ -73,6 +71,6 @@ export default function NewsletterSection() {
           * 실제 구독 기능은 작동하지 않으며, 포트폴리오 목적의 폼입니다.
         </p>
       </div>
-    </section>
+    </MainSectionWrapper>
   );
 }

--- a/src/components/home/OpenChatSection.jsx
+++ b/src/components/home/OpenChatSection.jsx
@@ -1,8 +1,9 @@
 import { Link } from "react-router-dom";
+import MainSectionWrapper from "@/components/common/layout/MainSectionWrapper";
 
 export default function OpenChatSection() {
   return (
-    <section className="bg-gray-50 py-32 px-4 sm:px-6 lg:px-8">
+    <MainSectionWrapper bg="bg-gray-50" className="overflow-hidden">
       <div className="max-w-screen-2xl mx-auto flex flex-col-reverse lg:flex-row items-center justify-between gap-12">
         {/* 왼쪽 텍스트 설명 */}
         <div className="flex-1 max-w-2xl lg:ml-7 text-center lg:text-left">
@@ -56,6 +57,6 @@ export default function OpenChatSection() {
           />
         </div>
       </div>
-    </section>
+    </MainSectionWrapper>
   );
 }

--- a/src/components/home/RegionMapSection.jsx
+++ b/src/components/home/RegionMapSection.jsx
@@ -3,6 +3,7 @@ import { regions } from "@/data/regions";
 import { useState } from "react";
 
 import { useRegionCounts } from "@/hooks/itinerary/useRegionCounts";
+import MainSectionWrapper from "@/components/common/layout/MainSectionWrapper";
 
 export default function RegionMapSection() {
   const [activeRegion, setActiveRegion] = useState(null);
@@ -18,7 +19,7 @@ export default function RegionMapSection() {
   const totalCount = Object.values(regionCounts).reduce((acc, v) => acc + v, 0);
 
   return (
-    <section className="bg-gray-100 py-20 px-4 sm:px-6 lg:px-8">
+    <MainSectionWrapper bg="bg-gray-100" className="overflow-hidden">
       <div className="max-w-screen-2xl mx-auto flex flex-col lg:flex-row items-center justify-between gap-10">
         {/* 왼쪽 설명 */}
         <div className="flex-1 max-w-2xl pl-7">
@@ -88,6 +89,6 @@ export default function RegionMapSection() {
           ))}
         </div>
       </div>
-    </section>
+    </MainSectionWrapper>
   );
 }

--- a/src/components/home/ReviewPreview.jsx
+++ b/src/components/home/ReviewPreview.jsx
@@ -6,6 +6,7 @@ import "swiper/css/navigation";
 import { Link } from "react-router-dom";
 import { useRecentReviews } from "@/hooks/review/useRecentReviews";
 import SkeletonImage from "@/components/common/loading/SkeletonImage";
+import MainSectionWrapper from "@/components/common/layout/MainSectionWrapper";
 
 export default function ReviewPreview() {
   const { data: reviews, isLoading } = useRecentReviews();
@@ -20,19 +21,19 @@ export default function ReviewPreview() {
   };
 
   return (
-    <section className="relative py-32 px-6 bg-gray-900 overflow-hidden">
+    <MainSectionWrapper className="overflow-hidden">
       {/* 배경 이미지 */}
       <img
         src="/images/review-bg.jpg"
         alt="여행자 리뷰 배경"
-        className="absolute inset-0 w-full h-full object-cover opacity-40"
+        className="absolute inset-0 w-full h-full object-cover opacity-40 z-0"
       />
 
       {/* 어두운 오버레이 */}
-      <div className="absolute inset-0 bg-black/20" />
+      <div className="absolute inset-0 bg-black/40 z-10" />
 
       {/* 콘텐츠 */}
-      <div className="relative z-10 max-w-screen-2xl mx-auto">
+      <div className="relative max-w-screen-2xl mx-auto z-20">
         {/* 제목 + 설명 */}
         <div className="text-center mb-12 text-white">
           <h2 className="text-3xl font-bold">여행의 흔적, 혼자 남긴 이야기</h2>
@@ -141,6 +142,6 @@ export default function ReviewPreview() {
           ))}
         </Swiper>
       </div>
-    </section>
+    </MainSectionWrapper>
   );
 }


### PR DESCRIPTION
### 변경 사항

- MainSectionWrapper 컴포넌트 생성 (bg, padding, containerClass 등 유연하게 설정 가능)
- 메인 페이지의 섹션별 컴포넌트에 공통 레이아웃 적용
- 섹션별 배경 이미지 및 오버레이 구조 통일