### PR TITLE
refactor: 마이페이지 카드 UI 리팩토링 및 fallback 처리 개선

### DIFF
--- a/src/components/mypage/MyChatRoomCard.jsx
+++ b/src/components/mypage/MyChatRoomCard.jsx
@@ -7,7 +7,7 @@ import { Bell } from "lucide-react";
 export default function MyChatRoomCard({ room }) {
   const navigate = useNavigate();
 
-  if (!room || !room.id || !room.name) {
+  if (!room?.id || !room?.name) {
     return (
       <div className="bg-gray-100 rounded-xl p-6 shadow-sm text-center text-gray-500">
         채팅방 정보를 불러올 수 없습니다.

--- a/src/components/mypage/MyItineraryCard.jsx
+++ b/src/components/mypage/MyItineraryCard.jsx
@@ -21,13 +21,7 @@ export default function MyItineraryCard({ itinerary }) {
     >
       {/* 이미지 영역 */}
       <div className="relative h-48 bg-gray-100">
-        {imageUrl ? (
-          <SkeletonImage src={imageUrl} alt={title} objectFit="cover" />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
-            이미지 없음
-          </div>
-        )}
+        <SkeletonImage src={imageUrl} alt={title} objectFit="cover" />
 
         {/* 날짜 배지 */}
         <div className="absolute bottom-3 right-3 bg-black/60 text-white text-xs px-3 py-1 rounded-full">

--- a/src/components/mypage/MyItineraryCard.jsx
+++ b/src/components/mypage/MyItineraryCard.jsx
@@ -7,6 +7,14 @@ export default function MyItineraryCard({ itinerary }) {
   const navigate = useNavigate();
   const { id, title, startDate, endDate, imageUrl } = itinerary;
 
+  if (!itinerary?.id || !itinerary?.title) {
+    return (
+      <div className="bg-gray-100 rounded-xl p-6 shadow-sm text-center text-gray-500">
+        여행 정보를 불러올 수 없습니다.
+      </div>
+    );
+  }
+
   return (
     <div
       onClick={() => navigate(`/itinerary/${id}`)}

--- a/src/components/mypage/MyReviewCard.jsx
+++ b/src/components/mypage/MyReviewCard.jsx
@@ -17,6 +17,14 @@ export default function MyReviewCard({ review = {} }) {
     reported = false,
   } = review;
 
+  if (!review?.id || !review?.title) {
+    return (
+      <div className="bg-gray-100 rounded-xl p-6 shadow-sm text-center text-gray-500">
+        리뷰 정보를 불러올 수 없습니다.
+      </div>
+    );
+  }
+
   return (
     <div
       onClick={() => navigate(`/reviews/${id}`)}

--- a/src/components/mypage/MyReviewCard.jsx
+++ b/src/components/mypage/MyReviewCard.jsx
@@ -31,13 +31,7 @@ export default function MyReviewCard({ review = {} }) {
     >
       {/* 이미지 영역 */}
       <div className="relative h-48 bg-gray-100">
-        {imageUrl ? (
-          <SkeletonImage src={imageUrl} alt={title} objectFit="cover" />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
-            이미지 없음
-          </div>
-        )}
+        <SkeletonImage src={imageUrl} alt={title} objectFit="cover" />
 
         {/* 작성일자 배지 */}
         <div className="absolute bottom-3 right-3 bg-black/60 text-white text-xs px-3 py-1 rounded-full">

--- a/src/components/mypage/ProfileInfoCard.jsx
+++ b/src/components/mypage/ProfileInfoCard.jsx
@@ -1,0 +1,38 @@
+import { Camera } from "lucide-react";
+
+export default function ProfileInfoCard({ user, onImageChange }) {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="relative group w-32 h-32 mb-4">
+        <img
+          src={user?.photoURL || "/images/default-profile.png"}
+          alt="프로필 이미지"
+          className="w-32 h-32 object-cover rounded-full border-2 border-white shadow-md"
+        />
+        <label
+          htmlFor="profile-image-upload"
+          className="absolute inset-0 bg-black/50 rounded-full flex items-center justify-center text-white opacity-0 group-hover:opacity-100 transition duration-200 cursor-pointer"
+        >
+          <Camera className="w-6 h-6" />
+          <input
+            id="profile-image-upload"
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={onImageChange}
+          />
+        </label>
+      </div>
+
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold text-white">
+          {user?.displayName || "닉네임 없음"}
+        </h2>
+        <p className="text-sm text-gray-400">@{user?.email?.split("@")[0]}</p>
+        <p className="text-sm text-white mt-2 whitespace-pre-wrap max-w-md">
+          {user?.bio?.trim() || "소개 문구가 없습니다."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mypage/ProfileSection.jsx
+++ b/src/components/mypage/ProfileSection.jsx
@@ -1,10 +1,12 @@
 import ProfileEditModal from "@/components/modal/ProfileEditModal";
 import ModalPortal from "@/components/common/modal/ModalPortal";
 import RoundedButton from "@/components/common/button/RoundedButton";
-import { Camera, Edit, LogOut, Settings } from "lucide-react";
+import { Edit, LogOut, Settings } from "lucide-react";
 import SettingModal from "@/components/modal/SettingModal";
 import ChangePasswordModal from "@/components/modal/ChangePasswordModal";
 import DeleteAccountModal from "@/components/modal/DeleteAccountModal";
+import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
+import ProfileInfoCard from "@/components/mypage/ProfileInfoCard";
 
 export default function ProfileSection({
   user,
@@ -21,41 +23,12 @@ export default function ProfileSection({
   return (
     <>
       <section className="flex flex-col items-center text-center px-6 py-16">
-        {/* 왼쪽: 프로필 정보 */}
-        <div className="relative group w-32 h-32 mb-4">
-          <img
-            src={user?.photoURL || "/images/default-profile.png"}
-            alt="프로필 이미지"
-            className="w-32 h-32 object-cover rounded-full border-2 border-white shadow-md"
-          />
-          {/* 업로드 버튼 (hover 시 표시) */}
-          <label
-            htmlFor="profile-image-upload"
-            className="absolute inset-0 bg-black/50 rounded-full flex items-center justify-center text-white opacity-0 group-hover:opacity-100 transition duration-200 cursor-pointer"
-          >
-            <Camera className="w-6 h-6" />
-            <input
-              id="profile-image-upload"
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={onImageChange}
-            />
-          </label>
+        {/* 프로필 정보 */}
+        <div className="py-10">
+          <ProfileInfoCard user={user} onImageChange={onImageChange} />
         </div>
 
-        {/* 텍스트 정보 */}
-        <div className="space-y-1 mb-8">
-          <h2 className="text-xl font-semibold text-white">
-            {user?.displayName || "닉네임 없음"}
-          </h2>
-          <p className="text-sm text-gray-400">@{user?.email?.split("@")[0]}</p>
-          <p className="text-sm text-white mt-2 whitespace-pre-wrap max-w-md">
-            {user?.bio?.trim() || "소개 문구가 없습니다."}
-          </p>
-        </div>
-
-        {/* 오른쪽: 버튼 그룹 */}
+        {/* 버튼 그룹 */}
         <div className="flex justify-center gap-4 mb-12 flex-wrap">
           <RoundedButton
             label="Profile"
@@ -65,7 +38,7 @@ export default function ProfileSection({
 
           <RoundedButton
             label="Setting"
-            onClick={toggleModal.openSetting} // 수정된 부분
+            onClick={toggleModal.openSetting}
             icon={<Settings className="text-sm" />}
           />
 
@@ -73,7 +46,15 @@ export default function ProfileSection({
             label="Logout"
             onClick={onLogout}
             isLoading={isLoggingOut}
-            icon={<LogOut className="w-4 h-4" />}
+            icon={
+              <span className="w-4 h-4 flex items-center justify-center">
+                {isLoggingOut ? (
+                  <ButtonSpinner size={16} color="white" />
+                ) : (
+                  <LogOut className="w-4 h-4" />
+                )}
+              </span>
+            }
           />
         </div>
 


### PR DESCRIPTION
### 변경 사항
- ProfileInfoCard 컴포넌트를 별도 파일로 분리하여 관심사 분리 및 재사용성 향상
- MyReviewCard, MyItineraryCard 컴포넌트에서 SkeletonImage를 직접 사용하고
불필요한 이미지 조건 분기(imageUrl ? ... : ...) 제거
- MyChatRoomCard, MyReviewCard, MyItineraryCard에 데이터 누락 시 fallback UI 추가
(예: id나 title 누락 시 표시 메시지 출력)
