### PR TITLE
refactor: 모달 인풋 필드 및 버튼 영역 공통 컴포넌트로 리팩토링

### DIFF
--- a/src/components/common/button/ModalFooterButton.jsx
+++ b/src/components/common/button/ModalFooterButton.jsx
@@ -1,0 +1,52 @@
+import PropTypes from "prop-types";
+import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
+
+export default function ModalFooterButton({
+  onClose,
+  onConfirm,
+  confirmLabel = "확인",
+  isLoading = false,
+  confirmColor = "black",
+  disabled = false,
+}) {
+  const baseConfirmColor =
+    confirmColor === "red"
+      ? "bg-red-600 hover:bg-red-700"
+      : "bg-black hover:bg-gray-900";
+
+  return (
+    <div className="flex justify-end gap-3 mt-4">
+      <button
+        type="button"
+        onClick={onClose}
+        className="px-4 py-2 rounded-lg border text-gray-600 hover:bg-gray-100"
+      >
+        취소
+      </button>
+
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={isLoading || disabled}
+        className={`px-4 py-2 rounded-lg text-white transition min-w-[80px] flex items-center justify-center disabled:opacity-60 ${baseConfirmColor}`}
+      >
+        {isLoading ? (
+          <span className="w-4 h-4 flex items-center justify-center">
+            <ButtonSpinner size={16} color="white" />
+          </span>
+        ) : (
+          <span>{confirmLabel}</span>
+        )}
+      </button>
+    </div>
+  );
+}
+
+ModalFooterButton.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  confirmLabel: PropTypes.string,
+  confirmColor: PropTypes.oneOf(["black", "red"]),
+  isLoading: PropTypes.bool,
+  disabled: PropTypes.bool,
+};

--- a/src/components/modal/ChangePasswordModal.jsx
+++ b/src/components/modal/ChangePasswordModal.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import ErrorMessage from "@/components/common/feedback/ErrorMessage";
 import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
+import FormInput from "../common/form/FormInput";
 
 export default function ChangePasswordModal({ isOpen, onClose, onSubmit }) {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -69,28 +70,31 @@ export default function ChangePasswordModal({ isOpen, onClose, onSubmit }) {
           </div>
 
           <div className="space-y-4">
-            <input
+            <FormInput
+              id="currentPassword"
+              name="currentPassword"
               type="password"
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
               placeholder="현재 비밀번호"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
             />
 
-            <input
+            <FormInput
+              id="newPassword"
+              name="newPassword"
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               placeholder="새 비밀번호"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
             />
 
-            <input
+            <FormInput
+              id="confirmPassword"
+              name="confirmPassword"
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               placeholder="비밀번호 확인"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
             />
 
             <ErrorMessage message={error} />

--- a/src/components/modal/ChangePasswordModal.jsx
+++ b/src/components/modal/ChangePasswordModal.jsx
@@ -4,8 +4,8 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
 import ErrorMessage from "@/components/common/feedback/ErrorMessage";
-import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
-import FormInput from "../common/form/FormInput";
+import FormInput from "@/components/common/form/FormInput";
+import ModalFooterButton from "@/components/common/button/ModalFooterButton";
 
 export default function ChangePasswordModal({ isOpen, onClose, onSubmit }) {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -99,28 +99,12 @@ export default function ChangePasswordModal({ isOpen, onClose, onSubmit }) {
 
             <ErrorMessage message={error} />
 
-            <div className="flex justify-end gap-3 mt-4">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 rounded-lg border text-gray-600 hover:bg-gray-100"
-              >
-                취소
-              </button>
-
-              <button
-                onClick={handleSubmit}
-                disabled={isLoading}
-                className="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-900 transition disabled:opacity-60 min-w-[72px] flex items-center justify-center"
-              >
-                {isLoading ? (
-                  <span className="w-4 h-4 flex items-center justify-center">
-                    <ButtonSpinner size={16} color="white" />
-                  </span>
-                ) : (
-                  <span>저장</span>
-                )}
-              </button>
-            </div>
+            <ModalFooterButton
+              onClose={onClose}
+              onConfirm={handleSubmit}
+              confirmLabel="저장"
+              isLoading={isLoading}
+            />
           </div>
         </div>
       </div>

--- a/src/components/modal/DeleteAccountModal.jsx
+++ b/src/components/modal/DeleteAccountModal.jsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "@/services/firebase";
 import FormInput from "@/components/common/form/FormInput";
+import ModalFooterButton from "@/components/common/button/ModalFooterButton";
 
 export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
   const [password, setPassword] = useState("");
@@ -117,27 +118,14 @@ export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
               </p>
             )}
 
-            <div className="flex justify-end gap-3 mt-4">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 rounded-lg border text-gray-600 hover:bg-gray-100"
-              >
-                취소
-              </button>
-              <button
-                onClick={() => (isPasswordUser ? handleConfirm() : onConfirm())}
-                disabled={isLoading || (isPasswordUser && !password)}
-                className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition disabled:opacity-60 min-w-[80px] flex items-center justify-center"
-              >
-                {isLoading ? (
-                  <span className="w-4 h-4 flex items-center justify-center">
-                    <ButtonSpinner size={16} color="white" />
-                  </span>
-                ) : (
-                  <span>탈퇴하기</span>
-                )}
-              </button>
-            </div>
+            <ModalFooterButton
+              onClose={onClose}
+              onConfirm={isPasswordUser ? handleConfirm : onConfirm}
+              confirmLabel="탈퇴하기"
+              confirmColor="red"
+              isLoading={isLoading}
+              disabled={isPasswordUser && !password}
+            />
           </div>
         </div>
       </div>

--- a/src/components/modal/DeleteAccountModal.jsx
+++ b/src/components/modal/DeleteAccountModal.jsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { Dialog } from "@headlessui/react";
 import { X, AlertTriangle } from "lucide-react";
 import PropTypes from "prop-types";
-import ErrorMessage from "@/components/common/feedback/ErrorMessage";
 
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "@/services/firebase";
+import FormInput from "@/components/common/form/FormInput";
 
 export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
   const [password, setPassword] = useState("");
@@ -100,14 +100,15 @@ export default function DeleteAccountModal({ isOpen, onClose, onConfirm }) {
                 <p className="text-sm text-gray-700">
                   탈퇴를 위해 비밀번호를 다시 입력해주세요.
                 </p>
-                <input
+                <FormInput
+                  id="password"
+                  name="password"
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="현재 비밀번호"
-                  className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring"
+                  error={error}
                 />
-                <ErrorMessage message={error} />
               </>
             ) : (
               <p className="text-sm text-gray-700">

--- a/src/components/modal/ProfileEditModal.jsx
+++ b/src/components/modal/ProfileEditModal.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useUpdateProfile } from "@/hooks/mypage/useUpdateProfile";
 import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
+import FormInput from "@/components/common/form/FormInput";
+import FormTextarea from "@/components/common/form/FormTextarea";
 
 export default function ProfileEditModal({ isOpen, onClose, user }) {
   const [displayName, setDisplayName] = useState(user?.displayName || "");
@@ -20,28 +22,23 @@ export default function ProfileEditModal({ isOpen, onClose, user }) {
       <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
         <h2 className="text-xl font-semibold mb-4 text-black">프로필 수정</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              닉네임
-            </label>
-            <input
-              type="text"
-              className="w-full border px-3 py-2 rounded text-sm text-black"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              소개 문구
-            </label>
-            <textarea
-              className="w-full border px-3 py-2 rounded resize-none text-sm text-black"
-              rows={3}
-              value={bio}
-              onChange={(e) => setBio(e.target.value)}
-            />
-          </div>
+          <FormInput
+            id="displayName"
+            name="displayName"
+            label="닉네임"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+
+          <FormTextarea
+            id="bio"
+            name="bio"
+            label="소개 문구"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            rows={3}
+          />
           <div className="flex justify-end gap-2 mt-4">
             <button
               type="button"

--- a/src/components/modal/ProfileEditModal.jsx
+++ b/src/components/modal/ProfileEditModal.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { useUpdateProfile } from "@/hooks/mypage/useUpdateProfile";
-import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
 import FormInput from "@/components/common/form/FormInput";
 import FormTextarea from "@/components/common/form/FormTextarea";
+import ModalFooterButton from "@/components/common/button/ModalFooterButton";
 
 export default function ProfileEditModal({ isOpen, onClose, user }) {
   const [displayName, setDisplayName] = useState(user?.displayName || "");
@@ -39,28 +39,13 @@ export default function ProfileEditModal({ isOpen, onClose, user }) {
             onChange={(e) => setBio(e.target.value)}
             rows={3}
           />
-          <div className="flex justify-end gap-2 mt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-100"
-            >
-              취소
-            </button>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="px-4 py-2 rounded bg-black text-white hover:bg-gray-900 transition disabled:opacity-60 min-w-[80px] flex items-center justify-center"
-            >
-              {isLoading ? (
-                <span className="w-4 h-4 flex items-center justify-center">
-                  <ButtonSpinner size={16} color="white" />
-                </span>
-              ) : (
-                <span>저장</span>
-              )}
-            </button>
-          </div>
+
+          <ModalFooterButton
+            onClose={onClose}
+            onConfirm={handleSubmit}
+            confirmLabel="저장"
+            isLoading={isLoading}
+          />
         </form>
       </div>
     </div>


### PR DESCRIPTION
### 변경 사항
1. ChangePasswordModal
- FormInput 공통 컴포넌트로 인풋 필드 통합 적용
2. ProfileEditModal
- FormInput, FormTextarea 공통 컴포넌트 적용
3. DeleteAccountModal
- FormInput 적용 및 기존 입력 필드 대체
4. ModalFooterButtons 공통 컴포넌트 생성
- 세 모달의 하단 버튼 영역 (취소 / 저장 / 탈퇴) 패턴을 하나로 통합
- 색상/라벨/로딩 상태를 prop으로 제어 가능
5. 추가사항
- 버튼 컴포넌트는 min-w 및 flex-center 스타일로 고정된 사이즈 유지
- 모달별 버튼 색상은 confirmColor prop으로 조절 가능 (기본 black, 탈퇴용 red)