### PR TITLE
Refactor: 마이페이지 프로필 수정 기능 리팩토링 및 오류 수정

### DIFF
--- a/src/components/modal/ProfileEditModal.jsx
+++ b/src/components/modal/ProfileEditModal.jsx
@@ -7,11 +7,11 @@ import ModalFooterButton from "@/components/common/button/ModalFooterButton";
 export default function ProfileEditModal({ isOpen, onClose, user }) {
   const [displayName, setDisplayName] = useState(user?.displayName || "");
   const [bio, setBio] = useState(user?.bio || "");
-  const { updateProfile, isLoading } = useUpdateProfile();
+  const mutation = useUpdateProfile();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateProfile({ displayName, bio });
+    mutation.mutate({ displayName, bio });
     onClose();
   };
 
@@ -44,7 +44,7 @@ export default function ProfileEditModal({ isOpen, onClose, user }) {
             onClose={onClose}
             onConfirm={handleSubmit}
             confirmLabel="저장"
-            isLoading={isLoading}
+            isLoading={mutation.isLoading}
           />
         </form>
       </div>

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -24,4 +24,5 @@ export const QUERY_KEYS = {
   USERS_BY_IDS: (userIds) => ["usersByIds", userIds],
   RECOMMENDATIONS: "recommendations",
   RECOMMENDATION_DETAIL: (id) => ["recommendation", id],
+  USER_STATS: (uid) => ["userStats", uid],
 };

--- a/src/hooks/mypage/useUpdateProfile.js
+++ b/src/hooks/mypage/useUpdateProfile.js
@@ -1,82 +1,32 @@
-import { useState } from "react";
 import { useDispatch } from "react-redux";
-import { useQueryClient } from "@tanstack/react-query";
-
 import { useUser } from "@/hooks/auth/useUser";
-import { updatePublicUserProfile } from "@/services/user/updatePublicUserProfile";
-import { updatePrivateUserProfile } from "@/services/user/updatePrivateUserProfile";
-import { updateUserContentProfile } from "@/services/user/updateUserContentProfile";
-import { updateUserState } from "@/services/user/updateUserState";
-import { updateFirebaseUserProfile } from "@/services/user/updateFirebaseUserProfile";
+import { useMutationWithFeedback } from "@/hooks/common/useMutationWithFeedback";
+import { updateUserProfileAll } from "@/services/mypage/updateUserProfileAll";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 
-export function useUpdateProfile() {
-  const { user, isLoading: isUserLoading } = useUser(); // 현재 로그인 사용자
+export const useUpdateProfile = () => {
+  const { user, isLoading: isUserLoading } = useUser();
   const dispatch = useDispatch();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const queryClient = useQueryClient();
 
-  /**
-   * 사용자 프로필 정보 업데이트
-   * @param {Object} params
-   * @param {string} params.displayName - 사용자 이름
-   * @param {string} params.bio - 자기소개
-   * @param {string} params.photoURL - 새 프로필 이미지 URL
-   */
-  const updateProfile = async ({ displayName, bio, photoURL }) => {
-    if (isUserLoading || !user) return;
+  return useMutationWithFeedback({
+    mutationFn: async ({ displayName, photoURL, bio }) => {
+      if (isUserLoading || !user) throw new Error("로그인이 필요합니다.");
 
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // 1. Firebase Auth 프로필 업데이트
-      await updateFirebaseUserProfile({ displayName, photoURL });
-
-      // 2. Firestore 공개 프로필 정보 업데이트
-      await updatePublicUserProfile({
+      await updateUserProfileAll({
         uid: user.uid,
         displayName,
         photoURL,
-      });
-
-      // 3. Firestore 비공개 프로필 정보 업데이트
-      await updatePrivateUserProfile({
-        uid: user.uid,
         bio,
-      });
-
-      // 4. 작성 콘텐츠에 반영 (리뷰, 일정, 채팅 등)
-      await updateUserContentProfile({
-        uid: user.uid,
-        displayName,
-        photoURL,
-      });
-
-      // 5. Redux 상태 업데이트
-      updateUserState({
         dispatch,
         user,
-        displayName,
-        photoURL,
-        bio,
       });
-
-      // 6. React Query 캐시 무효화
-      queryClient.invalidateQueries(["reviews"]);
-      queryClient.invalidateQueries(["itineraries"]);
-      queryClient.invalidateQueries(["chatRooms"]);
-    } catch (err) {
-      console.error("프로필 업데이트 실패:", err);
-      setError(err);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return {
-    updateProfile,
-    isLoading,
-    error,
-  };
-}
+    },
+    successMessage: "프로필이 성공적으로 업데이트되었습니다.",
+    errorMessage: "프로필 업데이트 중 오류가 발생했습니다.",
+    queryKeysToInvalidate: [
+      [QUERY_KEYS.REVIEWS],
+      [QUERY_KEYS.ITINERARIES],
+      [QUERY_KEYS.CHAT_ROOMS],
+    ],
+  });
+};

--- a/src/hooks/mypage/useUserStats.js
+++ b/src/hooks/mypage/useUserStats.js
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchUserStats } from "@/services/user/fetchUserStats";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 
 export const useUserStats = (uid) => {
   return useQuery({
-    queryKey: ["userStats", uid],
+    queryKey: QUERY_KEYS.USER_STATS(uid),
     queryFn: () => fetchUserStats(uid),
     enabled: !!uid,
     staleTime: 0,

--- a/src/services/mypage/updateUserProfileAll.js
+++ b/src/services/mypage/updateUserProfileAll.js
@@ -1,0 +1,35 @@
+import { updatePublicUserProfile } from "@/services/user/updatePublicUserProfile";
+import { updatePrivateUserProfile } from "@/services/user/updatePrivateUserProfile";
+import { updateUserContentProfile } from "@/services/user/updateUserContentProfile";
+import { updateUserState } from "@/services/user/updateUserState";
+import { updateFirebaseUserProfile } from "@/services/user/updateFirebaseUserProfile";
+
+export const updateUserProfileAll = async ({
+  uid,
+  displayName,
+  photoURL,
+  bio,
+  dispatch,
+  user,
+}) => {
+  // Firebase Auth 프로필
+  await updateFirebaseUserProfile({ displayName, photoURL });
+
+  // 공개 Firestore
+  await updatePublicUserProfile({ uid, displayName, photoURL });
+
+  // 비공개 Firestore
+  await updatePrivateUserProfile({ uid, bio });
+
+  // 사용자 콘텐츠(리뷰, 일정, 채팅)
+  await updateUserContentProfile({ uid, displayName, photoURL });
+
+  // Redux 상태 반영
+  updateUserState({
+    dispatch,
+    user,
+    displayName,
+    photoURL,
+    bio,
+  });
+};

--- a/src/services/mypage/updateUserProfileAll.js
+++ b/src/services/mypage/updateUserProfileAll.js
@@ -16,7 +16,7 @@ export const updateUserProfileAll = async ({
   await updateFirebaseUserProfile({ displayName, photoURL });
 
   // 공개 Firestore
-  await updatePublicUserProfile({ displayName, photoURL, bio });
+  await updatePublicUserProfile({ uid, displayName, photoURL, bio }); // 공개 여부 상관없이 uid로 경로 지정
 
   // 비공개 Firestore
   await updatePrivateUserProfile({ uid });

--- a/src/services/mypage/updateUserProfileAll.js
+++ b/src/services/mypage/updateUserProfileAll.js
@@ -16,10 +16,10 @@ export const updateUserProfileAll = async ({
   await updateFirebaseUserProfile({ displayName, photoURL });
 
   // 공개 Firestore
-  await updatePublicUserProfile({ uid, displayName, photoURL });
+  await updatePublicUserProfile({ displayName, photoURL, bio });
 
   // 비공개 Firestore
-  await updatePrivateUserProfile({ uid, bio });
+  await updatePrivateUserProfile({ uid });
 
   // 사용자 콘텐츠(리뷰, 일정, 채팅)
   await updateUserContentProfile({ uid, displayName, photoURL });

--- a/src/services/user/updatePrivateUserProfile.js
+++ b/src/services/user/updatePrivateUserProfile.js
@@ -7,9 +7,8 @@ import { db } from "@/services/firebase";
  * @param {string} params.uid - 사용자 UID
  * @param {string} params.bio - 자기소개
  */
-export async function updatePrivateUserProfile({ uid, bio }) {
+export async function updatePrivateUserProfile({ uid }) {
   const privateData = {
-    bio,
     updatedAt: serverTimestamp(),
   };
 

--- a/src/services/user/updatePublicUserProfile.js
+++ b/src/services/user/updatePublicUserProfile.js
@@ -8,7 +8,12 @@ import { db } from "@/services/firebase";
  * @param {string} params.displayName - 사용자 이름
  * @param {string} [params.photoURL] - 프로필 이미지 URL (선택)
  */
-export async function updatePublicUserProfile({ uid, displayName, photoURL }) {
+export async function updatePublicUserProfile({
+  uid,
+  displayName,
+  photoURL,
+  bio,
+}) {
   const publicData = {
     displayName,
     updatedAt: serverTimestamp(),
@@ -17,6 +22,8 @@ export async function updatePublicUserProfile({ uid, displayName, photoURL }) {
   if (photoURL !== undefined) {
     publicData.photoURL = photoURL;
   }
+
+  if (bio !== undefined) publicData.bio = bio;
 
   await setDoc(doc(db, "users_public", uid), publicData, { merge: true });
 }

--- a/src/services/user/updateUserState.js
+++ b/src/services/user/updateUserState.js
@@ -1,13 +1,13 @@
 import { setUser } from "@/store/userSlice";
 
 /**
- * Redux 상태에서 사용자 정보를 업데이트
+ * Redux 사용자 상태를 업데이트하는 헬퍼 함수
  * @param {Object} params
- * @param {Function} dispatch - redux dispatch 함수
- * @param {Object} user - 기존 사용자 정보
- * @param {string} displayName - 새 사용자 이름
- * @param {string} [photoURL] - 새 프로필 이미지 URL
- * @param {string} bio - 새 자기소개
+ * @param {Function} params.dispatch - Redux dispatch 함수
+ * @param {Object} params.user - 기존 사용자 객체
+ * @param {string} params.displayName - 새 사용자 이름
+ * @param {string} [params.photoURL] - 새 프로필 사진 URL (선택)
+ * @param {string} [params.bio] - 새 소개글 (선택)
  */
 export function updateUserState({
   dispatch,
@@ -16,13 +16,13 @@ export function updateUserState({
   photoURL,
   bio,
 }) {
-  dispatch(
-    setUser({
-      uid: user.uid,
-      email: user.email,
-      displayName,
-      photoURL: photoURL !== undefined ? photoURL : user.photoURL,
-      bio,
-    })
-  );
+  const newUser = {
+    uid: user.uid,
+    email: user.email,
+    displayName,
+    photoURL: photoURL ?? user.photoURL ?? "",
+    bio: bio ?? user.bio ?? "",
+  };
+
+  dispatch(setUser(newUser));
 }


### PR DESCRIPTION
### 주요 변경사항
1. useUpdateProfile 훅 리팩토링
- 프로필 수정 로직을 updateUserProfileAll 서비스 함수로 추상화
- Firestore의 공개/비공개 프로필 정보를 분리하여 명확한 책임 부여
2. updateUserState 유틸 개선
- 기존 불명확한 fallback 처리 로직을 ?? 연산자로 개선
- bio, photoURL 등의 초기 상태 설정을 안전하게 처리
3. useUserStats 훅 개선
- queryKey를 상수화하여 유지보수성과 예측 가능성 강화
4. ProfileEditModal 리팩토링
- 기존 updateProfile() 호출 방식에서 mutation.mutate() 방식으로 변경
- useUpdateProfile 훅과 통합된 구조로 개선

### 버그 수정
1. 마이페이지 사용자 정보 불러오지 않던 오류 수정
- Redux 상태에서 bio가 제대로 반영되지 않아 초기값이 비는 문제 해결
- observeAuth 내부에서 Firestore의 공개 프로필(users_public)에서 bio를 fetch하여 상태에 반영
2. 공개 프로필 업데이트 시 uid 누락 오류 수정
- updatePublicUserProfile에서 문서 경로 식별자 uid가 전달되지 않아 Firestore 업데이트 실패했던 문제 해결
