### PR TITLE
Feature: Kakao 지도 연동 및 추천 장소 마커 렌더링 구현

### DIFF
--- a/src/components/recommendation/KakaoMap.jsx
+++ b/src/components/recommendation/KakaoMap.jsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 
-export default function KakaoMap() {
+export default function KakaoMap({ address }) {
   useEffect(() => {
     const script = document.createElement("script");
     script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${
       import.meta.env.VITE_KAKAO_MAP_KEY
-    }&autoload=false`;
+    }&autoload=false&libraries=services`;
     script.async = true;
     document.head.appendChild(script);
 
@@ -16,10 +16,27 @@ export default function KakaoMap() {
           center: new window.kakao.maps.LatLng(37.5665, 126.978),
           level: 3,
         };
-        new window.kakao.maps.Map(container, options);
+        const map = new window.kakao.maps.Map(container, options);
+        // 주소 → 좌표 변환
+        const geocoder = new window.kakao.maps.services.Geocoder();
+        geocoder.addressSearch(address, (result, status) => {
+          if (status === window.kakao.maps.services.Status.OK) {
+            const coords = new window.kakao.maps.LatLng(
+              result[0].y,
+              result[0].x
+            );
+            new window.kakao.maps.Marker({
+              map,
+              position: coords,
+            });
+            map.setCenter(coords);
+          } else {
+            console.warn("주소 변환 실패:", status);
+          }
+        });
       });
     };
-  }, []);
+  }, [address]);
 
-  return <div id="map" className="w-full h-[400px]" />;
+  return <div id="map" className="w-full h-[400px] rounded-2xl" />;
 }

--- a/src/components/recommendation/KakaoMap.jsx
+++ b/src/components/recommendation/KakaoMap.jsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+export default function KakaoMap() {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${
+      import.meta.env.VITE_KAKAO_MAP_KEY
+    }&autoload=false`;
+    script.async = true;
+    document.head.appendChild(script);
+
+    script.onload = () => {
+      window.kakao.maps.load(() => {
+        const container = document.getElementById("map");
+        const options = {
+          center: new window.kakao.maps.LatLng(37.5665, 126.978),
+          level: 3,
+        };
+        new window.kakao.maps.Map(container, options);
+      });
+    };
+  }, []);
+
+  return <div id="map" className="w-full h-[400px]" />;
+}

--- a/src/components/recommendation/RecommendationDetail.jsx
+++ b/src/components/recommendation/RecommendationDetail.jsx
@@ -14,6 +14,7 @@ export default function RecommendationDetail({ data }) {
       <RecommendationLocation
         directions={data.directions}
         nearbyInfo={data.nearbyInfo}
+        locationInfo={data.locationInfo}
       />
 
       {/* 일정 만들기 CTA 섹션 */}

--- a/src/components/recommendation/RecommendationLocation.jsx
+++ b/src/components/recommendation/RecommendationLocation.jsx
@@ -1,10 +1,13 @@
 import { MapPin, Wand2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import KakaoMap from "@/components/recommendation/KakaoMap";
 
 export default function RecommendationLocation({
   directions = [],
   nearbyInfo = [],
+  lat,
+  lng,
 }) {
   return (
     <section className="py-24 px-6">
@@ -17,10 +20,14 @@ export default function RecommendationLocation({
           </p>
         </div>
 
-        {/* 지도 더미 */}
-        <div className="w-full h-[320px] bg-gray-200 rounded-2xl flex items-center justify-center text-gray-400 text-sm tracking-wide">
-          지도 영역 (1024×320)
-        </div>
+        {/* 카카오 지도 */}
+        {lat && lng ? (
+          <KakaoMap lat={lat} lng={lng} />
+        ) : (
+          <div className="w-full h-[320px] bg-gray-200 rounded-2xl flex items-center justify-center text-gray-400 text-sm tracking-wide">
+            지도 정보가 없습니다
+          </div>
+        )}
 
         {/* 찾아가는 방법 & 주변 정보 */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12 text-sm text-gray-700">

--- a/src/components/recommendation/RecommendationLocation.jsx
+++ b/src/components/recommendation/RecommendationLocation.jsx
@@ -6,8 +6,7 @@ import KakaoMap from "@/components/recommendation/KakaoMap";
 export default function RecommendationLocation({
   directions = [],
   nearbyInfo = [],
-  lat,
-  lng,
+  locationInfo,
 }) {
   return (
     <section className="py-24 px-6">
@@ -21,8 +20,8 @@ export default function RecommendationLocation({
         </div>
 
         {/* 카카오 지도 */}
-        {lat && lng ? (
-          <KakaoMap lat={lat} lng={lng} />
+        {locationInfo ? (
+          <KakaoMap address={locationInfo} />
         ) : (
           <div className="w-full h-[320px] bg-gray-200 rounded-2xl flex items-center justify-center text-gray-400 text-sm tracking-wide">
             지도 정보가 없습니다


### PR DESCRIPTION
### 작업 내용
- KakaoMap 컴포넌트 생성 및 Kakao Maps SDK 동적 로딩 처리
- 지도 초기 중심 좌표 설정 및 useEffect 기반 렌더링 흐름 구성
- Firestore에 저장된 locationInfo 주소를 받아 Kakao Geocoder로 좌표 변환
- 변환된 좌표에 마커 표시 및 지도 중심 이동 처리

### 구현 방식
- Kakao Maps SDK에 services 라이브러리 포함하여 Geocoder 사용 가능하도록 설정
- RecommendationLocation 컴포넌트에 locationInfo prop을 전달받아 지도 렌더링에 활용
- 지도 영역 비어있을 경우 graceful fallback 처리