### PR TITLE
perf: 클라이언트 전반 서버 요청 최적화 및 쿼리 캐시 정비

### DIFF
--- a/src/components/home/RegionMapSection.jsx
+++ b/src/components/home/RegionMapSection.jsx
@@ -19,7 +19,7 @@ function RegionMapSection() {
 
   if (!regionCounts) return null;
 
-  const totalCount = Object.values(regionCounts).reduce((acc, v) => acc + v, 0);
+  const totalCount = regionCounts.total;
 
   return (
     <MainSectionWrapper bg="bg-gray-100" className="overflow-hidden">

--- a/src/containers/itinerary/ItineraryFormContainer.jsx
+++ b/src/containers/itinerary/ItineraryFormContainer.jsx
@@ -40,7 +40,10 @@ export default function ItineraryFormContainer({ isEditMode = false }) {
     }
   }, [initialData, isEditMode]);
 
-  const { mutate: addMutate, isPending: isAdding } = useAddItinerary();
+  const { mutate: addMutate, isPending: isAdding } = useAddItinerary({
+    onSuccessCallback: (newId) => navigate(`/itinerary/${newId}`),
+  });
+
   const { mutate: updateMutate, isPending: isUpdating } = useMutation({
     mutationFn: ({ id, updatedData }) => updateItinerary(id, updatedData),
     onSuccess: () => navigate(`/itinerary/${id}`),
@@ -102,10 +105,9 @@ export default function ItineraryFormContainer({ isEditMode = false }) {
 
       isEditMode
         ? updateMutate({ id, updatedData: itineraryData })
-        : addMutate(itineraryData, {
-            onSuccess: (newId) => navigate(`/itinerary/${newId}`),
-          });
+        : addMutate(itineraryData);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       validateForm,
       title,

--- a/src/containers/itinerary/ItineraryListContainer.jsx
+++ b/src/containers/itinerary/ItineraryListContainer.jsx
@@ -16,18 +16,19 @@ export default function ItineraryListContainer() {
     if (!Array.isArray(itineraries)) return [];
 
     const convertToDate = (ts) => (ts ? new Date(ts) : new Date(0));
+    let sorted = itineraries;
 
-    return [...itineraries]
-      .sort((a, b) =>
-        activeFilter === "최신순"
-          ? convertToDate(b.createdAt) - convertToDate(a.createdAt)
-          : convertToDate(a.createdAt) - convertToDate(b.createdAt)
-      )
-      .filter((itinerary) =>
-        itinerary.location
-          ?.toLowerCase()
-          .includes(searchKeyword.trim().toLowerCase())
+    if (activeFilter === "오래된순") {
+      sorted = [...itineraries].sort(
+        (a, b) => convertToDate(a.createdAt) - convertToDate(b.createdAt)
       );
+    }
+
+    return sorted.filter((itinerary) =>
+      itinerary.location
+        ?.toLowerCase()
+        .includes(searchKeyword.trim().toLowerCase())
+    );
   }, [itineraries, activeFilter, searchKeyword]);
 
   const handleFilterChange = useCallback((filter) => {

--- a/src/containers/mypage/MyPageContainer.jsx
+++ b/src/containers/mypage/MyPageContainer.jsx
@@ -22,7 +22,7 @@ export default function MyPageContainer() {
     enabled: activeTab === "review",
   });
 
-  const myChatRoomsQuery = useMyChatRooms(user?.uid, {
+  const myChatRoomsQuery = useMyChatRooms({
     enabled: activeTab === "chat",
   });
 

--- a/src/containers/mypage/MyPageContainer.jsx
+++ b/src/containers/mypage/MyPageContainer.jsx
@@ -14,7 +14,7 @@ export default function MyPageContainer() {
     setActiveTab(tab);
   }, []);
 
-  const myItinerariesQuery = useMyItineraries(user?.uid, {
+  const myItinerariesQuery = useMyItineraries({
     enabled: activeTab === "itinerary",
   });
 

--- a/src/containers/review/CommentListContainer.jsx
+++ b/src/containers/review/CommentListContainer.jsx
@@ -7,7 +7,9 @@ import CommentList from "@/components/review/CommentList";
 export default function CommentListContainer({ reviewId }) {
   const { user, isLoading: isUserLoading } = useUser();
   const [content, setContent] = useState("");
-  const { data: comments, isLoading } = useComments(reviewId);
+  const { data: comments, isLoading } = useComments(reviewId, {
+    enabled: !!reviewId,
+  });
   const { mutate, isPending } = useAddComment(reviewId);
 
   const handleSubmit = useCallback(

--- a/src/containers/review/ReviewListContainer.jsx
+++ b/src/containers/review/ReviewListContainer.jsx
@@ -22,9 +22,7 @@ export default function ReviewListContainer() {
     let result = [...reviews];
 
     // 정렬
-    if (sort === "최신순") {
-      result.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-    } else if (sort === "별점순") {
+    if (sort === "별점순") {
       result.sort((a, b) => b.rating - a.rating);
     } else if (sort === "좋아요순") {
       result.sort((a, b) => (b.likesCount || 0) - (a.likesCount || 0));

--- a/src/hooks/auth/useLogin.js
+++ b/src/hooks/auth/useLogin.js
@@ -13,6 +13,7 @@ export function useLogin() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
+  // 이메일/비밀번호 로그인
   const {
     mutate: handleEmailPasswordLogin,
     isPending: isEmailLoading,
@@ -35,8 +36,10 @@ export function useLogin() {
       console.error("이메일 로그인 실패:", err.message);
       alert("이메일 또는 비밀번호가 잘못되었습니다.");
     },
+    retry: 0,
   });
 
+  // 구글 로그인
   const { mutate: handleGoogleLogin, isPending: isGoogleLoading } = useMutation(
     {
       mutationFn: signInWithGoogle,
@@ -56,6 +59,7 @@ export function useLogin() {
         console.error("Google 로그인 실패:", err.message);
         alert("Google 로그인 중 오류가 발생했습니다.");
       },
+      retry: 1,
     }
   );
 

--- a/src/hooks/auth/useSignUp.js
+++ b/src/hooks/auth/useSignUp.js
@@ -36,26 +36,26 @@ export function useSignUp() {
         throw new Error("비밀번호가 일치하지 않습니다.");
       }
 
-      const result = await signUpUser(
-        trimmedEmail,
-        trimmedPassword,
-        trimmedNickname
-      );
-      return result;
+      return await signUpUser(trimmedEmail, trimmedPassword, trimmedNickname);
     },
     successMessage: "회원가입이 완료되었습니다!",
+    errorMessage: "회원가입에 실패했습니다.",
     redirectTo: "/",
-    onSuccessCallback: (result) => {
+
+    onSuccessCallback: ({ user }) => {
       dispatch(
         setUser({
-          uid: result.user.uid,
-          email: result.user.email,
-          displayName: result.user.displayName,
-          photoURL: result.user.photoURL,
+          uid: user.uid,
+          email: user.email,
+          displayName: user.displayName,
+          photoURL: user.photoURL,
         })
       );
     },
-    errorMessage: "회원가입에 실패했습니다.",
+
+    mutationOptions: {
+      retry: 0,
+    },
   });
 
   return mutation;

--- a/src/hooks/chat/useChatMessages.js
+++ b/src/hooks/chat/useChatMessages.js
@@ -7,6 +7,7 @@ import {
   onSnapshot,
   getDocs,
   limit,
+  startAfter,
 } from "firebase/firestore";
 import { db } from "@/services/firebase";
 import { insertDateSeparators } from "@/utils/chatUtils";
@@ -16,6 +17,7 @@ export const useChatMessages = (roomId) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [lastDoc, setLastDoc] = useState(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const messagesPerPage = useRef(50); // 한 번에 불러올 수
 
@@ -61,13 +63,14 @@ export const useChatMessages = (roomId) => {
   // 이전 메시지 불러오기
   const loadMoreMessages = useCallback(async () => {
     if (!roomId || !lastDoc) return;
-    setLoading(true);
+    setLoadingMore(true);
 
     try {
       const moreQuery = query(
         collection(db, "chatMessages"),
         where("roomId", "==", roomId),
         orderBy("createdAt", "desc"),
+        startAfter(lastDoc),
         limit(messagesPerPage.current)
       );
 
@@ -80,9 +83,9 @@ export const useChatMessages = (roomId) => {
       console.error("이전 메시지 로드 중 오류:", err);
       setError(err);
     } finally {
-      setLoading(false);
+      setLoadingMore(false);
     }
   }, [roomId, lastDoc]);
 
-  return { messages, loading, error, loadMoreMessages };
+  return { messages, loading, loadingMore, error, loadMoreMessages };
 };

--- a/src/hooks/chat/useChatRooms.js
+++ b/src/hooks/chat/useChatRooms.js
@@ -11,6 +11,8 @@ export const useChatRooms = ({
   limitCount = 10,
   orderDirection = "desc",
   filterBy = null,
+  enabled = true,
+  ...options
 } = {}) => {
   return useQuery({
     queryKey: QUERY_KEYS.CHAT_ROOMS_FILTERED(
@@ -18,8 +20,17 @@ export const useChatRooms = ({
       orderDirection,
       filterBy
     ),
-    queryFn: () => fetchChatRooms({ limitCount, orderDirection, filterBy }),
-    refetchInterval: 30000,
-    staleTime: 10000,
+    queryFn: () =>
+      fetchChatRooms({
+        limitCount,
+        orderDirection,
+        filterBy,
+      }),
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 30 * 60 * 1000,
+    refetchInterval: 30000, // 30초 polling 유지 (실시간성 고려)
+    refetchOnWindowFocus: true, // 창에 다시 포커스 시 갱신
+    enabled,
+    ...options,
   });
 };

--- a/src/hooks/chat/useMyChatRooms.js
+++ b/src/hooks/chat/useMyChatRooms.js
@@ -1,15 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { fetchMyChatRooms } from "@/services/chat/fetchMyChatRooms";
+import { useSelector } from "react-redux";
 
 /**
  * 내가 참여한 채팅방 목록 훅
  */
-export const useMyChatRooms = (uid, options = {}) => {
+export const useMyChatRooms = (options = {}) => {
+  const user = useSelector((state) => state.user.user);
+
   return useQuery({
-    queryKey: QUERY_KEYS.MY_CHAT_ROOMS(uid),
-    enabled: !!uid && options.enabled !== false,
-    queryFn: () => fetchMyChatRooms(uid),
+    queryKey: QUERY_KEYS.MY_CHAT_ROOMS(user?.uid),
+    queryFn: () => fetchMyChatRooms(user.uid),
+    enabled: !!user?.uid && options.enabled !== false,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,
     refetchInterval: 30000,

--- a/src/hooks/chat/useReportMessage.js
+++ b/src/hooks/chat/useReportMessage.js
@@ -7,7 +7,18 @@ export const useReportMessage = () => {
 
   return useMutation({
     mutationFn: async ({ messageId, roomId, reason }) => {
-      return await reportMessage({ messageId, roomId, reason, user });
+      if (!user?.uid) {
+        throw new Error("로그인한 사용자만 신고할 수 있습니다.");
+      }
+
+      return reportMessage({ messageId, roomId, reason, user });
+    },
+    onSuccess: () => {
+      alert("신고가 성공적으로 접수되었습니다.");
+    },
+    onError: (error) => {
+      console.error("메시지 신고 오류:", error.message);
+      alert("신고 중 오류가 발생했습니다.");
     },
   });
 };

--- a/src/hooks/chat/useUsersByIds.js
+++ b/src/hooks/chat/useUsersByIds.js
@@ -6,9 +6,15 @@ import { getUsersByIds } from "@/services/user/getUsersByIds";
  * 여러 유저의 공개 프로필 정보를 가져오는 훅
  */
 export const useUsersByIds = (userIds = []) => {
+  const enabled = Array.isArray(userIds) && userIds.length > 0;
+
   return useQuery({
     queryKey: QUERY_KEYS.USERS_BY_IDS(userIds),
-    enabled: Array.isArray(userIds) && userIds.length > 0,
+    enabled,
     queryFn: () => getUsersByIds(userIds),
+    staleTime: 5 * 60 * 1000,
+    select: (data) => {
+      return data?.filter(Boolean);
+    },
   });
 };

--- a/src/hooks/itinerary/useAddItinerary.js
+++ b/src/hooks/itinerary/useAddItinerary.js
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "react-redux";
+import { auth } from "@/services/firebase";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { createItineraryWithImage } from "@/services/itinerary/createItineraryWithImage";
 
@@ -21,6 +22,14 @@ export const useAddItinerary = ({
     onSuccess: (newId) => {
       alert("일정이 성공적으로 등록되었습니다!");
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ITINERARIES] });
+
+      const uid = auth.currentUser?.uid;
+      if (uid) {
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.MY_ITINERARIES(uid),
+        });
+      }
+
       onSuccessCallback(newId);
     },
     onError: (error) => {

--- a/src/hooks/itinerary/useDeleteItinerary.js
+++ b/src/hooks/itinerary/useDeleteItinerary.js
@@ -3,11 +3,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { auth } from "@/services/firebase";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { deleteItineraryAndDecreaseCount } from "@/services/itinerary/deleteItineraryWithCount";
+import { useAuthState } from "react-firebase-hooks/auth";
 
 export const useDeleteItinerary = ({
   onSuccess = () => {},
   onError = () => {},
 } = {}) => {
+  const [user] = useAuthState(auth);
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -18,14 +20,13 @@ export const useDeleteItinerary = ({
 
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ITINERARIES] });
 
-      const uid = auth.currentUser?.uid;
-      if (uid) {
+      if (user?.uid) {
         queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.MY_ITINERARIES(uid),
+          queryKey: QUERY_KEYS.MY_ITINERARIES(user.uid),
         });
       }
 
-      onSuccess(); // UI 쪽에서 정의한 행동 실행
+      onSuccess(); // UI 정의 동작 실행
     },
 
     onError: onError,

--- a/src/hooks/itinerary/useItineraries.js
+++ b/src/hooks/itinerary/useItineraries.js
@@ -2,12 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { fetchItineraries } from "@/services/itinerary/fetchItineraries";
 
-export const useItineraries = () => {
+export const useItineraries = (enabled = true) => {
   return useQuery({
     queryKey: [QUERY_KEYS.ITINERARIES],
     queryFn: () => fetchItineraries(20),
     staleTime: 5 * 60 * 1000,
     cacheTime: 30 * 60 * 1000,
+    select: (data) => data.sort((a, b) => b.createdAt - a.createdAt),
+    enabled,
     onError: (err) => {
       console.error("일정 데이터를 불러오는 중 오류 발생:", err);
     },

--- a/src/hooks/itinerary/useItineraryDetail.js
+++ b/src/hooks/itinerary/useItineraryDetail.js
@@ -6,6 +6,8 @@ export const useItineraryDetail = (id) => {
   return useQuery({
     queryKey: QUERY_KEYS.ITINERARY_DETAIL(id),
     queryFn: () => fetchItineraryById(id),
+    staleTime: 3 * 60 * 1000,
     enabled: !!id, // id가 존재할 때만 fetch
+    onError: (err) => console.error("상세 일정 불러오기 실패:", err),
   });
 };

--- a/src/hooks/itinerary/useMyItineraries.js
+++ b/src/hooks/itinerary/useMyItineraries.js
@@ -9,8 +9,9 @@ export const useMyItineraries = (options = {}) => {
 
   return useQuery({
     queryKey: QUERY_KEYS.MY_ITINERARIES(user?.uid),
-    enabled: !loading && !!user?.uid && options.enabled !== false,
     queryFn: () => fetchMyItineraries(user.uid),
+    staleTime: 5 * 60 * 1000,
+    enabled: !loading && !!user?.uid && options.enabled !== false,
     ...options,
   });
 };

--- a/src/hooks/itinerary/useRegionCounts.js
+++ b/src/hooks/itinerary/useRegionCounts.js
@@ -42,5 +42,9 @@ export const useRegionCounts = () => {
     queryKey: [QUERY_KEYS.REGION_COUNTS],
     queryFn: fetchRegionCounts,
     staleTime: 5 * 60 * 1000,
+    select: (data) => ({
+      ...data,
+      total: Object.values(data).reduce((a, b) => a + b, 0),
+    }),
   });
 };

--- a/src/hooks/mypage/useUserStats.js
+++ b/src/hooks/mypage/useUserStats.js
@@ -2,12 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchUserStats } from "@/services/user/fetchUserStats";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 
-export const useUserStats = (uid) => {
+export const useUserStats = (uid, options = {}) => {
   return useQuery({
     queryKey: QUERY_KEYS.USER_STATS(uid),
     queryFn: () => fetchUserStats(uid),
-    enabled: !!uid,
-    staleTime: 0,
-    refetchOnWindowFocus: true,
+    enabled: !!uid && options.enabled !== false,
+    staleTime: 60 * 1000, // 1분 동안 fresh 상태 유지
+    cacheTime: 5 * 60 * 1000, // 5분 간 메모리 캐시 유지
+    refetchOnWindowFocus: false,
+    ...options,
   });
 };

--- a/src/hooks/recommendation/useRecommendationDetail.js
+++ b/src/hooks/recommendation/useRecommendationDetail.js
@@ -2,10 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchRecommendationDetail } from "@/services/recommendation/fetchRecommendationDetail";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 
-export function useRecommendationDetail(id) {
+export function useRecommendationDetail(id, options = {}) {
   return useQuery({
     queryKey: QUERY_KEYS.RECOMMENDATION_DETAIL(id),
     queryFn: () => fetchRecommendationDetail(id),
-    enabled: !!id, // id가 있을 때만 실행
+    enabled: !!id,
+    staleTime: 10 * 60 * 1000, // 10분 동안 fresh 상태 유지
+    cacheTime: 30 * 60 * 1000, // 캐시도 유지
+    ...options,
   });
 }

--- a/src/hooks/recommendation/useRecommendationList.js
+++ b/src/hooks/recommendation/useRecommendationList.js
@@ -2,9 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchRecommendationList } from "@/services/recommendation/fetchRecommendationList";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 
-export function useRecommendationList() {
+export function useRecommendationList(options = {}) {
   return useQuery({
     queryKey: [QUERY_KEYS.RECOMMENDATIONS],
     queryFn: fetchRecommendationList,
+    staleTime: 10 * 60 * 1000, // 10분 간 fresh 처리
+    cacheTime: 30 * 60 * 1000, // 30분 간 메모리 유지
+    refetchOnWindowFocus: false,
+    ...options,
   });
 }

--- a/src/hooks/review/useComments.js
+++ b/src/hooks/review/useComments.js
@@ -3,10 +3,16 @@ import { useQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { fetchComments } from "@/services/review/fetchComments";
 
-export const useComments = (reviewId) => {
+export const useComments = (reviewId, options = {}) => {
   return useQuery({
     queryKey: QUERY_KEYS.COMMENTS(reviewId),
     queryFn: () => fetchComments(reviewId),
-    enabled: !!reviewId,
+    enabled: !!reviewId && options.enabled !== false,
+    staleTime: 3 * 60 * 1000, // 캐싱 최적화
+    cacheTime: 10 * 60 * 1000,
+    onError: (err) => {
+      console.error("댓글 불러오기 오류:", err);
+    },
+    ...options,
   });
 };

--- a/src/hooks/review/useDeleteReview.js
+++ b/src/hooks/review/useDeleteReview.js
@@ -2,15 +2,18 @@ import { auth } from "@/services/firebase";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { deleteReviewWithCount } from "@/services/review/deleteReviewWithCount";
 import { useMutationWithFeedback } from "@/hooks/common/useMutationWithFeedback";
+import { useAuthState } from "react-firebase-hooks/auth";
 
 export const useDeleteReview = () => {
+  const [user] = useAuthState(auth);
+
   return useMutationWithFeedback({
     mutationFn: deleteReviewWithCount,
     successMessage: "리뷰가 삭제되었습니다.",
     errorMessage: "리뷰 삭제 중 오류가 발생했습니다.",
     queryKeysToInvalidate: [
       [QUERY_KEYS.REVIEWS],
-      QUERY_KEYS.MY_REVIEWS(auth.currentUser?.uid),
+      QUERY_KEYS.MY_REVIEWS(user?.uid),
     ],
     redirectTo: "/reviews",
   });

--- a/src/hooks/review/useMyReviews.js
+++ b/src/hooks/review/useMyReviews.js
@@ -9,8 +9,13 @@ export const useMyReviews = (options = {}) => {
 
   return useQuery({
     queryKey: QUERY_KEYS.MY_REVIEWS(user?.uid),
-    enabled: !loading && !!user?.uid && options.enabled !== false,
     queryFn: () => fetchMyReviews(user.uid),
+    enabled: !loading && !!user?.uid && options.enabled !== false,
+    staleTime: 5 * 60 * 1000, // 5분 동안 fresh 상태 유지
+    cacheTime: 30 * 60 * 1000, // 30분 동안 캐시 유지
+    onError: (err) => {
+      console.error("내 리뷰 불러오기 오류:", err);
+    },
     ...options,
   });
 };

--- a/src/hooks/review/useReviewDetail.js
+++ b/src/hooks/review/useReviewDetail.js
@@ -12,22 +12,20 @@ export const useReviewDetail = (reviewId) => {
   return useQuery({
     queryKey: QUERY_KEYS.REVIEW_DETAIL(reviewId),
     queryFn: async () => {
-      try {
-        const docRef = doc(db, "reviews", reviewId);
-        const snapshot = await getDoc(docRef);
+      const docRef = doc(db, "reviews", reviewId);
+      const snapshot = await getDoc(docRef);
 
-        if (!snapshot.exists()) {
-          throw new Error("리뷰가 존재하지 않습니다.");
-        }
-
-        return { id: snapshot.id, ...snapshot.data() };
-      } catch (error) {
-        if (error.message === "리뷰가 존재하지 않습니다.") {
-          throw error;
-        }
-        throw new Error(`리뷰 조회 중 오류가 발생했습니다: ${error.message}`);
+      if (!snapshot.exists()) {
+        throw new Error("리뷰가 존재하지 않습니다.");
       }
+
+      return { id: snapshot.id, ...snapshot.data() };
     },
     enabled: !!reviewId,
+    staleTime: 5 * 60 * 1000, // 5분
+    cacheTime: 30 * 60 * 1000, // 30분
+    onError: (err) => {
+      console.error("리뷰 상세 조회 오류:", err);
+    },
   });
 };

--- a/src/hooks/review/useReviews.js
+++ b/src/hooks/review/useReviews.js
@@ -2,13 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { fetchReviews } from "@/services/review/fetchReviews";
 
-export const useReviews = () =>
-  useQuery({
+export const useReviews = (enabled = true) => {
+  return useQuery({
     queryKey: [QUERY_KEYS.REVIEWS],
     queryFn: fetchReviews,
     staleTime: 5 * 60 * 1000,
     cacheTime: 30 * 60 * 1000,
+    select: (data) =>
+      data.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)),
+    enabled,
     onError: (err) => {
-      console.error("리뷰 불러오기 오류:", err);
+      console.error("리뷰 데이터를 불러오는 중 오류 발생:", err);
     },
   });
+};


### PR DESCRIPTION
### 주요 변경 사항

1. 일정 (Itinerary)
- 일정 목록 정렬 로직을 쿼리 select로 이전하여 렌더링 최적화
- 일정 등록 후 invalidateQueries 범위 최적화 및 myItineraries 캐시 무효화 추가
- 일정 상세 쿼리에 staleTime, onError 추가
- 내 일정 조회 쿼리에 staleTime, enabled 조건 개선
- 지역별 일정 수 통계 쿼리에 select 최적화 및 total 포함 처리
- RegionMapSection에서 중복된 total 계산 제거
- ItineraryFormContainer에서 useAddItinerary 훅 구조에 맞게 최적화
- useMyItineraries 훅에서 uid 인자 제거 및 호출부 수정
-  useDeleteItinerary 훅에서 auth.currentUser 제거 → useAuthState 사용

2. 리뷰 (Review)
- 리뷰 목록 조회 훅 useReviews 최적화 및 정렬 로직 개선
- useReviewDetail, useMyReviews에 staleTime, cacheTime, onError 설정
- useDeleteReview 훅에서 auth.currentUser 제거 → useAuthState 사용

3. 채팅 (Chat)
- useMyChatRooms 구조 개선 및 refetchInterval, enabled 조건 정리
- useChatRooms, useCreateChatRoom 서버 요청 최적화 및 에러 처리 개선
- useChatMessages 무한 스크롤 최적화 및 loadingMore 분리
- useReportMessage에 사용자 피드백 처리 및 구조 개선
- useUsersByIds 최적화: staleTime, select 추가

4. 댓글 (Comment)
- useComments 훅 옵션 확장 및 CommentListContainer 적용

5. 추천 여행지 (Recommendation)
- useRecommendationList, useRecommendationDetail에 staleTime, cacheTime 등 추가

6. 마이페이지
- useUserStats에 staleTime 및 refetchOnWindowFocus 적용

7. 인증(Auth)
- useLogin 훅 요청 최적화 및 retry 정책 반영
- useSignUp 훅 retry 비활성화 및 유효성 검사 개선