### PR TITLE
feat: SkeletonImage에 폴백 이미지(fallbackSrc) 기능 추가

### DIFF
--- a/src/components/common/loading/SkeletonImage.jsx
+++ b/src/components/common/loading/SkeletonImage.jsx
@@ -4,11 +4,13 @@ export default function SkeletonImage({
   src,
   alt = "이미지",
   className = "",
+  fallbackSrc = "/images/no_image.png",
   objectFit = "cover",
   absolute = false,
   size = "w-full h-full",
 }) {
   const [loaded, setLoaded] = useState(false);
+  const [currentSrc, setCurrentSrc] = useState(src);
   const [error, setError] = useState(false);
 
   const wrapperClass = `${absolute ? "absolute inset-0" : "relative"} ${size}`;
@@ -38,12 +40,20 @@ export default function SkeletonImage({
 
       {/* 실제 이미지 */}
       <img
-        src={src}
+        src={currentSrc}
         alt={alt}
         loading="lazy"
         decoding="async"
         onLoad={() => setLoaded(true)}
-        onError={() => setError(true)}
+        onError={() => {
+          if (currentSrc !== fallbackSrc) {
+            // 첫 실패 → fallback 이미지로 교체
+            setCurrentSrc(fallbackSrc);
+          } else {
+            // fallback도 실패 → 텍스트 fallback
+            setError(true);
+          }
+        }}
         className={imageClass}
         style={{ willChange: "opacity" }}
       />


### PR DESCRIPTION
- 이미지 로드 실패 시 fallbackSrc로 자동 교체
- fallbackSrc까지 실패할 경우 텍스트 메시지 출력
- currentSrc 상태를 통해 이미지 소스 전환 제어
- 기본 fallbackSrc는 /images/no_image.png