### PR TITLE
Feat: 공개 일정 공유 기능 구현

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,8 @@ service cloud.firestore {
     }
 
     match /itineraries/{itineraryId} {
-      allow read, create: if isSignedIn();
+      allow read: if request.auth != null || resource.data.isPublic == true;
+      allow create: if isSignedIn();
 
       allow update: if isSignedIn() && (
         resource.data.createdBy.uid == request.auth.uid ||

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import Callback from "@/pages/auth/Callback";
 import ProtectedRoute from "@/components/common/route/ProtectedRoute";
 import LoadingSpinner from "@/components/common/loading/LoadingSpinner.jsx";
 import FloatingButtons from "@/components/common/button/FloatingButtons";
+import PublicItineraryPage from "@/pages/itinerary/Public";
 
 const Home = React.lazy(() => import("@/pages/home/Home"));
 const CreateItineraryPage = React.lazy(() =>
@@ -119,6 +120,10 @@ function App() {
                 }
               />
             </Route>
+            <Route
+              path="/itinerary/public/:id"
+              element={<PublicItineraryPage />}
+            />
             <Route path="/reviews">
               <Route
                 index

--- a/src/components/itinerary/ItineraryDetail.jsx
+++ b/src/components/itinerary/ItineraryDetail.jsx
@@ -40,7 +40,10 @@ export default function ItineraryDetail({
             label="등록일"
             value={
               createdAt
-                ? format(new Date(createdAt), "yyyy.MM.dd")
+                ? format(
+                    createdAt.toDate?.() ?? new Date(createdAt),
+                    "yyyy.MM.dd"
+                  )
                 : "정보 없음"
             }
           />

--- a/src/components/itinerary/PublicItinerary.jsx
+++ b/src/components/itinerary/PublicItinerary.jsx
@@ -1,47 +1,6 @@
-import { useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { doc, getDoc } from "firebase/firestore";
-import { db } from "@/services/firebase";
 import ItineraryDetail from "@/components/itinerary/ItineraryDetail";
-import NotFoundMessage from "@/components/common/feedback/NotFoundMessage";
-import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 
-function PublicItinerary() {
-  const { id } = useParams();
-  const [itinerary, setItinerary] = useState(null);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const snap = await getDoc(doc(db, "itineraries", id));
-        if (!snap.exists()) {
-          setError("존재하지 않는 일정입니다.");
-          return;
-        }
-
-        const data = snap.data();
-        if (!data.isPublic) {
-          setError("비공개 일정입니다.");
-          return;
-        }
-
-        setItinerary(data);
-      } catch (err) {
-        console.error(err);
-        setError("일정 조회 중 오류가 발생했습니다.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [id]);
-
-  if (loading) return <LoadingSpinner />;
-  if (error) return <NotFoundMessage message={error} />;
-
+function PublicItinerary({ id, itinerary }) {
   return (
     <div className="max-w-5xl mx-auto pt-10 px-4">
       <ItineraryDetail

--- a/src/components/itinerary/PublicItinerary.jsx
+++ b/src/components/itinerary/PublicItinerary.jsx
@@ -1,0 +1,47 @@
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/services/firebase";
+
+function PublicItinerary() {
+  const { id } = useParams();
+  const [itinerary, setItinerary] = useState(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const snap = await getDoc(doc(db, "itineraries", id));
+        if (!snap.exists()) {
+          setError("존재하지 않는 일정입니다.");
+          return;
+        }
+
+        const data = snap.data();
+        if (!data.isPublic) {
+          setError("비공개 일정입니다.");
+          return;
+        }
+
+        setItinerary(data);
+      } catch (err) {
+        console.error(err);
+        setError("일정 조회 중 오류가 발생했습니다.");
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  if (error) return <div className="p-6 text-center text-red-500">{error}</div>;
+  if (!itinerary) return <div className="p-6 text-center">로딩 중...</div>;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">{itinerary.title}</h1>
+      <p className="text-gray-600">{itinerary.summary}</p>
+    </div>
+  );
+}
+
+export default PublicItinerary;

--- a/src/components/itinerary/PublicItinerary.jsx
+++ b/src/components/itinerary/PublicItinerary.jsx
@@ -2,11 +2,15 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "@/services/firebase";
+import ItineraryDetail from "@/components/itinerary/ItineraryDetail";
+import NotFoundMessage from "@/components/common/feedback/NotFoundMessage";
+import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 
 function PublicItinerary() {
   const { id } = useParams();
   const [itinerary, setItinerary] = useState(null);
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -27,19 +31,26 @@ function PublicItinerary() {
       } catch (err) {
         console.error(err);
         setError("일정 조회 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchData();
   }, [id]);
 
-  if (error) return <div className="p-6 text-center text-red-500">{error}</div>;
-  if (!itinerary) return <div className="p-6 text-center">로딩 중...</div>;
+  if (loading) return <LoadingSpinner />;
+  if (error) return <NotFoundMessage message={error} />;
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">{itinerary.title}</h1>
-      <p className="text-gray-600">{itinerary.summary}</p>
+    <div className="max-w-5xl mx-auto pt-10 px-4">
+      <ItineraryDetail
+        itineraryId={id}
+        itinerary={itinerary}
+        isOwner={false}
+        onDelete={() => {}}
+        isDeletePending={false}
+      />
     </div>
   );
 }

--- a/src/components/mypage/MyItineraryCard.jsx
+++ b/src/components/mypage/MyItineraryCard.jsx
@@ -3,6 +3,7 @@ import { Edit2, Share2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { formatDateOnly } from "@/utils/formatDate";
 import SkeletonImage from "@/components/common/loading/SkeletonImage";
+import { shareItinerary } from "@/services/itinerary/shareItinerary";
 
 function MyItineraryCard({ itinerary }) {
   const navigate = useNavigate();
@@ -29,19 +30,20 @@ function MyItineraryCard({ itinerary }) {
     [navigate, id]
   );
 
-  const handleShareClick = useCallback((e) => {
-    e.stopPropagation();
-    alert("공유 기능은 추후 지원됩니다.");
-  }, []);
+  const handleShareClick = useCallback(
+    async (e) => {
+      e.stopPropagation();
 
-  if (!itinerary?.id || !itinerary?.title) {
-    return (
-      <div className="bg-gray-100 rounded-xl p-6 shadow-sm text-center text-gray-500">
-        여행 정보를 불러올 수 없습니다.
-      </div>
-    );
-  }
-
+      try {
+        await shareItinerary(id);
+        alert("공유 링크가 복사되었습니다!");
+      } catch (error) {
+        console.error("공유 실패:", error);
+        alert("공유 링크 생성에 실패했습니다.");
+      }
+    },
+    [id]
+  );
   return (
     <div
       onClick={handleCardClick}

--- a/src/containers/itinerary/PublicItineraryContainer.jsx
+++ b/src/containers/itinerary/PublicItineraryContainer.jsx
@@ -1,0 +1,46 @@
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/services/firebase";
+import NotFoundMessage from "@/components/common/feedback/NotFoundMessage";
+import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
+import PublicItinerary from "@/components/itinerary/PublicItinerary";
+
+export default function PublicItineraryContainer() {
+  const { id } = useParams();
+  const [itinerary, setItinerary] = useState(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const snap = await getDoc(doc(db, "itineraries", id));
+        if (!snap.exists()) {
+          setError("존재하지 않는 일정입니다.");
+          return;
+        }
+
+        const data = snap.data();
+        if (!data.isPublic) {
+          setError("비공개 일정입니다.");
+          return;
+        }
+
+        setItinerary(data);
+      } catch (err) {
+        console.error(err);
+        setError("일정 조회 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <NotFoundMessage message={error} />;
+
+  return <PublicItinerary id={id} itinerary={itinerary} />;
+}

--- a/src/pages/itinerary/Public.jsx
+++ b/src/pages/itinerary/Public.jsx
@@ -1,0 +1,9 @@
+import PublicItinerary from "@/components/itinerary/PublicItinerary";
+
+export default function PublicItineraryPage() {
+  return (
+    <div className="max-w-4xl mx-auto pt-10 px-4">
+      <PublicItinerary />
+    </div>
+  );
+}

--- a/src/pages/itinerary/Public.jsx
+++ b/src/pages/itinerary/Public.jsx
@@ -1,9 +1,5 @@
 import PublicItinerary from "@/components/itinerary/PublicItinerary";
 
 export default function PublicItineraryPage() {
-  return (
-    <div className="max-w-4xl mx-auto pt-10 px-4">
-      <PublicItinerary />
-    </div>
-  );
+  return <PublicItinerary />;
 }

--- a/src/pages/itinerary/Public.jsx
+++ b/src/pages/itinerary/Public.jsx
@@ -1,5 +1,9 @@
 import PublicItineraryContainer from "@/containers/itinerary/PublicItineraryContainer";
 
 export default function PublicItineraryPage() {
-  return <PublicItineraryContainer />;
+  return (
+    <div className="pt-16">
+      <PublicItineraryContainer />;
+    </div>
+  );
 }

--- a/src/pages/itinerary/Public.jsx
+++ b/src/pages/itinerary/Public.jsx
@@ -1,5 +1,5 @@
-import PublicItinerary from "@/components/itinerary/PublicItinerary";
+import PublicItineraryContainer from "@/containers/itinerary/PublicItineraryContainer";
 
 export default function PublicItineraryPage() {
-  return <PublicItinerary />;
+  return <PublicItineraryContainer />;
 }

--- a/src/services/itinerary/shareItinerary.js
+++ b/src/services/itinerary/shareItinerary.js
@@ -1,0 +1,23 @@
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "@/services/firebase";
+
+/**
+ * 일정 공유 링크를 생성하고 클립보드에 복사합니다.
+ * @param {string} itineraryId - 공유할 일정의 문서 ID
+ * @returns {string} - 복사된 공유 링크
+ * @throws {Error} - Firestore 업데이트 또는 복사 실패 시
+ */
+export async function shareItinerary(itineraryId) {
+  if (!itineraryId) throw new Error("일정 ID가 없습니다.");
+
+  const docRef = doc(db, "itineraries", itineraryId);
+
+  // Firestore 공개 설정
+  await updateDoc(docRef, { isPublic: true });
+
+  // 공유 링크 생성
+  const shareLink = `${window.location.origin}/itinerary/public/${itineraryId}`;
+  await navigator.clipboard.writeText(shareLink);
+
+  return shareLink;
+}


### PR DESCRIPTION
### 주요 변경 사항
1. 공유 링크 생성 기능
- shareItinerary(itineraryId) 서비스 함수 추가: Firestore에 isPublic: true 업데이트 후 클립보드에 공유 링크 복사
2. 사용자 일정 카드에 공유 버튼 연동
- MyItineraryCard에서 공유 버튼 클릭 시 shareItinerary() 호출
3. 공개 일정 조회 페이지 추가
- /itinerary/public/:id 경로 추가
- 비공개/삭제된 일정 접근 시 오류 메시지 출력 처리
4. 공개 일정 페이지 컴포넌트 구조화
- PublicItineraryContainer: Firestore에서 일정 데이터 조회 및 오류 처리
- PublicItinerary: 상세 렌더링 (재사용을 위해 ItineraryDetail 컴포넌트 활용)
5. 보안 규칙 수정
- Firestore 보안 규칙에서 itineraries 컬렉션의 read 조건에 isPublic == true 허용 추가
6. 기타 개선 및 처리
- createdAt 필드에서 포맷 오류 발생 시 안전하게 fallback 처리
- 상세 컴포넌트 ItineraryDetail 내 카드형 UI 렌더링 안정화
- 상단 헤더 간격 보정 (pt-16)