### PR TITLE
feat: 404 Not Found 페이지 추가 및 라우팅 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ const RecommendationListPage = React.lazy(() =>
 const RecommendationDetailPage = React.lazy(() =>
   import("@/pages/recommendations/Detail")
 );
+const NotFound = React.lazy(() => import("@/pages/errors/NotFound"));
 
 function App() {
   const dispatch = useDispatch();
@@ -76,7 +77,7 @@ function App() {
 
   return (
     <div className="flex flex-col min-h-screen">
-      {!isChatDetailPage && !isOAuthCallbackPage && <Header />}
+      {!isChatDetailPage && !isOAuthCallbackPage && !NotFound && <Header />}
 
       {/* main에 flex-grow를 줘서 Routes가 영역을 채우게 함 */}
       <main className="flex-grow">
@@ -212,12 +213,13 @@ function App() {
                 }
               />
             </Route>
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
       </main>
 
       {!isHome && <FloatingButtons />}
-      {!isChatDetailPage && !isOAuthCallbackPage && <Footer />}
+      {!isChatDetailPage && !isOAuthCallbackPage && !NotFound && <Footer />}
     </div>
   );
 }

--- a/src/pages/errors/NotFound.jsx
+++ b/src/pages/errors/NotFound.jsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+import { Ghost } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-800 px-4">
+      {/* 아이콘과 숫자 */}
+      <div className="flex flex-col items-center space-y-2 mb-8">
+        <Ghost className="w-10 h-10 text-gray-400" />
+        <h1 className="text-8xl font-extrabold tracking-widest text-gray-300">
+          404
+        </h1>
+      </div>
+
+      {/* 메시지 */}
+      <p className="text-lg text-center text-gray-600 mb-6">
+        죄송합니다. 요청하신 페이지를 찾을 수 없습니다.
+        <br className="hidden sm:block" />
+        입력하신 주소가 잘못되었거나, 존재하지 않는 경로일 수 있습니다.
+      </p>
+
+      {/* 홈 버튼 */}
+      <Link
+        to="/"
+        className="inline-block px-6 py-3 rounded-full bg-gray-800 text-white text-sm font-medium shadow-md hover:bg-gray-700 transition"
+      >
+        홈으로 돌아가기
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## 변경 내용

- 존재하지 않는 경로에 접근했을 때 사용자에게 안내하는 404 Not Found 페이지 추가
- React Router에서 `*` 경로를 통해 모든 미정의 라우팅을 404 페이지로 연결

## 구현 상세

- `src/pages/errors/NotFound.jsx` 생성
  - Ghost 아이콘 + 흐릿한 404 숫자 + 안내 문구 + 홈으로 돌아가기 버튼 구성
- `App.jsx`의 `<Routes>`에 다음 라우팅 추가:
  ```jsx
  <Route path="*" element={<NotFound />} />