### PR TITLE
feat: FormSelect 공통 컴포넌트 생성 및 여행 지역 선택 기능 연동

### DIFF
--- a/src/components/common/form/FormSelect.jsx
+++ b/src/components/common/form/FormSelect.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { ChevronDown } from "lucide-react";
+import {
+  formBaseStyle,
+  formVisualStyle,
+  getFormBorderColor,
+} from "@/styles/formStyles";
+import ErrorMessage from "@/components/common/feedback/ErrorMessage"; // 경로는 실제 프로젝트 구조에 따라 조정하세요
+
+function FormSelect({
+  label,
+  id,
+  name,
+  value,
+  onChange,
+  options = [],
+  placeholder = "선택해주세요",
+  error,
+}) {
+  return (
+    <div>
+      {label && (
+        <label
+          htmlFor={id}
+          className="block mb-1 text-sm font-bold text-gray-700"
+        >
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <select
+          id={id}
+          name={name}
+          value={value}
+          onChange={onChange}
+          className={`${formBaseStyle} ${getFormBorderColor(
+            error
+          )} ${formVisualStyle} pr-10 appearance-none`}
+        >
+          <option value="">{placeholder}</option>
+          {options.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+      </div>
+      {error && <ErrorMessage message={error} />}
+    </div>
+  );
+}
+
+FormSelect.propTypes = {
+  label: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ).isRequired,
+  placeholder: PropTypes.string,
+  error: PropTypes.string,
+};
+
+export default React.memo(FormSelect);

--- a/src/components/itinerary/ItineraryForm.jsx
+++ b/src/components/itinerary/ItineraryForm.jsx
@@ -5,6 +5,8 @@ import ImageUploader from "@/components/common/upload/ImageUploader";
 import FormInput from "@/components/common/form/FormInput";
 import FormTextarea from "@/components/common/form/FormTextarea";
 import React from "react";
+import FormSelect from "@/components/common/form/FormSelect";
+import { regions } from "@/data/regions";
 
 /**
  * ItineraryForm – 여행 일정 생성/수정용 폼
@@ -32,6 +34,11 @@ export default function ItineraryForm({
   isSubmitting,
   submitLabel,
 }) {
+  const regionOptions = regions.map((region) => ({
+    value: region.name,
+    label: region.name,
+  }));
+
   const formContainer =
     "mt-12 space-y-6 bg-white/60 backdrop-blur-lg p-6 sm:p-8 md:p-10 rounded-3xl shadow-md border border-white/30 text-gray-800";
 
@@ -71,13 +78,13 @@ export default function ItineraryForm({
               error={errors.title}
             />
 
-            <FormInput
+            <FormSelect
               label="여행 지역"
               id="location"
               name="location"
               value={location}
               onChange={(e) => setLocation(e.target.value)}
-              placeholder="여행할 지역을 입력하세요"
+              options={regionOptions}
               error={errors.location}
             />
 


### PR DESCRIPTION
- FormSelect 컴포넌트 생성 (label + 사용자 정의 셀렉트 UI + ChevronDown 아이콘 포함)
- formStyles 적용하여 기존 FormInput과 일관된 디자인 구성
- 지역 데이터(regions.js)와 연동하여 select 박스에 한국어 지역명 표시
- 여행 지역 값은 slug가 아닌 name(한국어)로 등록되도록 value 구조 조정
- ItineraryForm 내 location 입력 필드를 FormInput → FormSelect로 변경