### PR TITLE
fix: 이메일 로그인 시 signIn() 실행되지 않던 오류 수정 (#141)

### DIFF
--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -41,7 +41,13 @@ export default function LoginForm({
           </header>
 
           {/* 로그인 폼 */}
-          <form className="space-y-5" onSubmit={onSubmit}>
+          <form
+            className="space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit(); // => LoginFormContainer → useLogin → mutate()
+            }}
+          >
             {/* 이메일 입력 */}
             <FormInput
               label="이메일"

--- a/src/services/auth/auth.js
+++ b/src/services/auth/auth.js
@@ -14,7 +14,18 @@ import { auth } from "@/services/firebase";
  * @returns {Promise<UserCredential>}
  */
 export async function signIn(email, password) {
-  return await signInWithEmailAndPassword(auth, email, password);
+  try {
+    const result = await signInWithEmailAndPassword(auth, email, password);
+    return result;
+  } catch (err) {
+    console.error("로그인 실패:", err.code, err.message);
+
+    if (err.code === "auth/network-request-failed") {
+      await signOut(auth); // 꼬인 세션 초기화
+    }
+
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## 작업 내용

- 이메일 로그인 시도 시 `signIn()` 함수가 호출되지 않던 문제 수정
- `<form onSubmit={handleEmailPasswordLogin}>` 구조에서 이벤트 객체가 mutate()로 전달되어 실행 중단됨
- `LoginForm`에서 `onSubmit`을 래핑하여 `e.preventDefault()` 호출 추가
- Firebase 인증 흐름 점검 및 보완:
  - signIn 실패 시 `auth/network-request-failed` → `signOut(auth)` 처리
  - useMutation 흐름에 콘솔 디버깅 로그 추가

---

## 관련 이슈

Closes #141