### PR TITLE
fix: 지도 통계에 일정 수가 반영되지 않던 오류 수정 (#143)

### DIFF
--- a/src/data/regions.js
+++ b/src/data/regions.js
@@ -9,7 +9,7 @@ export const regions = [
   {
     name: "서울/경기",
     slug: "seoul",
-    position: { top: "32%", left: "49%" },
+    position: { top: "31%", left: "49%" },
   },
   {
     name: "인천",
@@ -17,27 +17,27 @@ export const regions = [
     position: { top: "33%", left: "38%" },
   },
   {
-    name: "강원",
+    name: "강원도",
     slug: "gangwon",
     position: { top: "25%", left: "63%" },
   },
   {
-    name: "충청",
+    name: "충청도",
     slug: "chungcheong",
     position: { top: "45%", left: "47%" },
   },
   {
-    name: "전북/전남",
+    name: "전라도",
     slug: "jeolla",
     position: { top: "60%", left: "45%" },
   },
   {
-    name: "경북/경남",
+    name: "경상도",
     slug: "gyeongsang",
     position: { top: "52%", left: "63%" },
   },
   {
-    name: "제주",
+    name: "제주도",
     slug: "jeju",
     position: { top: "88%", left: "36%" },
   },

--- a/src/hooks/itinerary/useRegionCounts.js
+++ b/src/hooks/itinerary/useRegionCounts.js
@@ -11,8 +11,7 @@ import { QUERY_KEYS } from "@/constants/queryKeys";
  */
 
 const LOCATION_MAP = {
-  서울: "seoul",
-  경기도: "seoul", // 서울 & 경기로 묶음
+  "서울/경기": "seoul", // 서울 & 경기로 묶음
   인천: "incheon",
   강원도: "gangwon",
   충청도: "chungcheong",


### PR DESCRIPTION
### 작업 내용

- 메인 페이지 지도 섹션의 지역별 일정 통계(count)가 반영되지 않던 문제 수정
- Firestore 일정 문서의 `location` 필드 값 `"서울/경기"`가 `LOCATION_MAP`에 정의되어 있지 않아 통계 계산에서 누락되는 이슈가 발생
- `LOCATION_MAP`에 `"서울/경기": "seoul"` 항목을 추가하여 정상적으로 카운트되도록 반영

---

### 관련 이슈

Closes #143
