### PR TITLE
fix: 리뷰 등록 시 이미지 누락되는 문제 수정

### DIFF
--- a/src/services/review/createReview.js
+++ b/src/services/review/createReview.js
@@ -38,6 +38,8 @@ export async function createReview(review, user) {
   let imageUrl = "";
   if (image instanceof File) {
     imageUrl = await uploadImage(image, "reviews", user.uid);
+  } else if (typeof image === "string") {
+    imageUrl = image;
   }
 
   const reviewData = {


### PR DESCRIPTION
### 문제 요약

리뷰 작성 시 이미지가 정상적으로 업로드되었음에도 불구하고, Firestore에 imageUrl 필드가 빈 문자열로 저장되는 문제가 발생 
이로 인해 리뷰 상세 페이지에서 이미지가 표시되지 않음.

### 원인
- createReview() 함수에서 image instanceof File 조건만 처리되고 있었고, image가 string(URL)인 경우는 반영되지 않아 imageUrl이 빈 문자열로 남는 문제가 있었음.

### 해결 내용
- typeof image === "string" 조건을 추가하여, string 타입의 이미지 URL도 imageUrl 필드에 정상적으로 반영되도록 수정

### 관련 이슈
Closes #146